### PR TITLE
Add release target for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,13 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
 
+release: manifests kustomize
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(eval TMP_ODIR := $(shell mktemp -d))
+	$(KUSTOMIZE) build config/default > $(TMP_ODIR)/k4e-operator.yaml
+	gh release create v$(VERSION) --notes "Release v$(VERSION) of K4E Operator" --title "Release v$(VERSION)" '$(TMP_ODIR)/k4e-operator.yaml# K4E Operator'
+	rm -rf $(TMP_ODIR)
+
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)


### PR DESCRIPTION
In order to allow a quick release of the operator, assuming an image was
uploaded to the image registry and identified by $IMAGE_NAME, run the following:

```
IMG=${IMAGE_NAME} make release
```

The result of the command will create new release on github that
contains a single file that can be used to deploy the operator, e.g.:

 ```
 kubectl apply -f https://github.com/masayag/k4e-operator/releases/download/v0.0.1/k4e-operator.yaml
 ```
    
 The `make release` requires github cli ([gh](https://cli.github.com/)) to be installed.

Signed-off-by: Moti Asayag <masayag@redhat.com>