### PR TITLE
Retry updating the EdgeDevice status

### DIFF
--- a/client/yggdrasil/post_data_message_for_device_responses.go
+++ b/client/yggdrasil/post_data_message_for_device_responses.go
@@ -26,6 +26,12 @@ func (o *PostDataMessageForDeviceReader) ReadResponse(response runtime.ClientRes
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewPostDataMessageForDeviceBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewPostDataMessageForDeviceUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -73,6 +79,27 @@ func (o *PostDataMessageForDeviceOK) Error() string {
 }
 
 func (o *PostDataMessageForDeviceOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewPostDataMessageForDeviceBadRequest creates a PostDataMessageForDeviceBadRequest with default headers values
+func NewPostDataMessageForDeviceBadRequest() *PostDataMessageForDeviceBadRequest {
+	return &PostDataMessageForDeviceBadRequest{}
+}
+
+/*PostDataMessageForDeviceBadRequest handles this case with default header values.
+
+Error
+*/
+type PostDataMessageForDeviceBadRequest struct {
+}
+
+func (o *PostDataMessageForDeviceBadRequest) Error() string {
+	return fmt.Sprintf("[POST /data/{device_id}/out][%d] postDataMessageForDeviceBadRequest ", 400)
+}
+
+func (o *PostDataMessageForDeviceBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/controllers/edgedeployment_controller.go
+++ b/controllers/edgedeployment_controller.go
@@ -140,8 +140,9 @@ func (r *EdgeDeploymentReconciler) removeDeploymentFromDevice(ctx context.Contex
 			newDeployments = append(newDeployments, deployment)
 		}
 	}
+	patch := client.MergeFrom(edgeDevice.DeepCopy())
 	edgeDevice.Status.Deployments = newDeployments
-	err := r.EdgeDeviceRepository.UpdateStatus(ctx, &edgeDevice)
+	err := r.EdgeDeviceRepository.PatchStatus(ctx, &edgeDevice, &patch)
 	if err != nil {
 		return err
 	}
@@ -184,8 +185,9 @@ func (r *EdgeDeploymentReconciler) addDeploymentsToDevices(ctx context.Context, 
 	for _, edgeDevice := range edgeDevices {
 		if !hasDeployment(edgeDevice, name) {
 			deploymentStatus := managementv1alpha1.Deployment{Name: name, Phase: managementv1alpha1.Deploying}
+			patch := client.MergeFrom(edgeDevice.DeepCopy())
 			edgeDevice.Status.Deployments = append(edgeDevice.Status.Deployments, deploymentStatus)
-			err := r.EdgeDeviceRepository.UpdateStatus(ctx, &edgeDevice)
+			err := r.EdgeDeviceRepository.PatchStatus(ctx, &edgeDevice, &patch)
 			if err != nil {
 				errs = append(errs, err)
 				continue

--- a/controllers/edgedevice_controller.go
+++ b/controllers/edgedevice_controller.go
@@ -86,8 +86,9 @@ func (r *EdgeDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 		}
 
+		patch := client.MergeFrom(edgeDevice.DeepCopy())
 		edgeDevice.Status.DataOBC = &obc.Name
-		err = r.EdgeDeviceRepository.UpdateStatus(ctx, edgeDevice)
+		err = r.EdgeDeviceRepository.PatchStatus(ctx, edgeDevice, &patch)
 		if err != nil {
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, err
 		}

--- a/internal/repository/edgedevice/edgedevice.go
+++ b/internal/repository/edgedevice/edgedevice.go
@@ -25,8 +25,8 @@ func (r *Repository) Create(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice
 	return r.client.Create(ctx, edgeDevice)
 }
 
-func (r *Repository) UpdateStatus(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice) error {
-	return r.client.Status().Update(ctx, edgeDevice)
+func (r *Repository) PatchStatus(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice, patch *client.Patch) error {
+	return r.client.Status().Patch(ctx, edgeDevice, *patch)
 }
 
 func (r *Repository) Patch(ctx context.Context, old, new *v1alpha1.EdgeDevice) error {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -183,6 +183,9 @@ func init() {
           "200": {
             "description": "Success"
           },
+          "400": {
+            "description": "Error"
+          },
           "401": {
             "description": "Unauthorized"
           },
@@ -855,6 +858,9 @@ func init() {
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Error"
           },
           "401": {
             "description": "Unauthorized"

--- a/restapi/operations/yggdrasil/post_data_message_for_device_responses.go
+++ b/restapi/operations/yggdrasil/post_data_message_for_device_responses.go
@@ -35,6 +35,30 @@ func (o *PostDataMessageForDeviceOK) WriteResponse(rw http.ResponseWriter, produ
 	rw.WriteHeader(200)
 }
 
+// PostDataMessageForDeviceBadRequestCode is the HTTP code returned for type PostDataMessageForDeviceBadRequest
+const PostDataMessageForDeviceBadRequestCode int = 400
+
+/*PostDataMessageForDeviceBadRequest Error
+
+swagger:response postDataMessageForDeviceBadRequest
+*/
+type PostDataMessageForDeviceBadRequest struct {
+}
+
+// NewPostDataMessageForDeviceBadRequest creates PostDataMessageForDeviceBadRequest with default headers values
+func NewPostDataMessageForDeviceBadRequest() *PostDataMessageForDeviceBadRequest {
+
+	return &PostDataMessageForDeviceBadRequest{}
+}
+
+// WriteResponse to the client
+func (o *PostDataMessageForDeviceBadRequest) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(400)
+}
+
 // PostDataMessageForDeviceUnauthorizedCode is the HTTP code returned for type PostDataMessageForDeviceUnauthorized
 const PostDataMessageForDeviceUnauthorizedCode int = 401
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -70,6 +70,8 @@ paths:
       responses:
         "200":
           description: Success
+        "400":
+          description: Error
         "401":
           description: Unauthorized
         "403":


### PR DESCRIPTION
The PR uses the patch method for updating the edge-device status.
In addition, it retries 3 times in case of a failure when the device
posts its information to the operator.

ECOPROJECT-255

Signed-off-by: Moti Asayag <masayag@redhat.com>