### PR TITLE
Relax hardware requirements

### DIFF
--- a/api/v1alpha1/edgedevice_types.go
+++ b/api/v1alpha1/edgedevice_types.go
@@ -249,10 +249,10 @@ type Interface struct {
 	HasCarrier bool `json:"hasCarrier,omitempty"`
 
 	// ipv4 addresses
-	IPV4Addresses []string `json:"ipv4Addresses"`
+	IPV4Addresses []string `json:"ipv4Addresses,omitempty"`
 
 	// ipv6 addresses
-	IPV6Addresses []string `json:"ipv6Addresses"`
+	IPV6Addresses []string `json:"ipv6Addresses,omitempty"`
 
 	// mac address
 	MacAddress string `json:"macAddress,omitempty"`

--- a/config/crd/bases/management.k4e.io_edgedevices.yaml
+++ b/config/crd/bases/management.k4e.io_edgedevices.yaml
@@ -261,8 +261,6 @@ spec:
                           type: string
                       required:
                       - flags
-                      - ipv4Addresses
-                      - ipv6Addresses
                       type: object
                     type: array
                   memory:


### PR DESCRIPTION
Interfaces might not have IP addresses configured.
We should support storing information about interface without IP
address.

Signed-off-by: Moti Asayag <masayag@redhat.com>