### PR TITLE
Update release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ gen-manifests: manifests kustomize # generates manifests for deploying the opera
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > $(TMP_ODIR)/k4e-operator.yaml
 
-release: manifests kustomize gen-manifests
+release: gen-manifests
 	gh release create v$(VERSION) --notes "Release v$(VERSION) of K4E Operator" --title "Release v$(VERSION)" '$(TMP_ODIR)/k4e-operator.yaml# K4E Operator'
 	rm -rf $(TMP_ODIR)
 


### PR DESCRIPTION
Remove redundant targets from the 'release' target since they are being
invoked by the 'gen-manifests'

Signed-off-by: Moti Asayag <masayag@redhat.com>