### PR TITLE
TLS: Enable Mutual TLS connection

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,6 +62,10 @@ spec:
       protocol: TCP
       port: 8888
       targetPort: 8888
+    - name: https
+      protocol: TCP
+      port: 8043
+      targetPort: 8043
   selector:
     control-plane: controller-manager
   type: ClusterIP

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-openapi/validate v0.19.10
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.1.2
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20210818162813-3eee31c01875
 	github.com/onsi/ginkgo v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -317,10 +317,12 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=

--- a/internal/mtls/ca.go
+++ b/internal/mtls/ca.go
@@ -115,15 +115,15 @@ func (conf *TLSConfig) InitCertificates() (*tls.Config, []*x509.Certificate, err
 	return tlsConfig, CACertChain, nil
 }
 
-func (conf *TLSConfig) CreateRegistrationClient() error {
-
-	name := fmt.Sprintf("%s-%s",
-		regClientSecretNamePrefix,
-		utilrand.String(regClientSecretNameRandomLen))
+func (conf *TLSConfig) CreateRegistrationClientCerts() error {
 
 	if len(conf.caProvider) == 0 {
 		return fmt.Errorf("Cannot get ca provider")
 	}
+
+	name := fmt.Sprintf("%s-%s",
+		regClientSecretNamePrefix,
+		utilrand.String(regClientSecretNameRandomLen))
 
 	certData, err := conf.caProvider[0].CreateRegistrationCertificate(name)
 	if err != nil {

--- a/internal/mtls/ca.go
+++ b/internal/mtls/ca.go
@@ -1,0 +1,193 @@
+package mtls
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/jakub-dzon/k4e-operator/internal/yggdrasil"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	regClientSecretNameRandomLen = 10
+	regClientSecretNamePrefix    = "reg-client-ca"
+	regClientSecretLabelKey      = "reg-client-ca"
+)
+
+// The main reason to have an interface here is to be able to extend this to
+// future Cert providers, like:
+// - Vault
+// - Acme protocol
+// Keeping as an interface, so in future users can decice.
+type CAProvider interface {
+	GetName() string
+	GetCACertificate() (*CertificateGroup, error)
+	CreateRegistrationCertificate(name string) (map[string][]byte, error)
+}
+
+type TLSConfig struct {
+	config           *tls.Config
+	client           client.Client
+	caProvider       []CAProvider
+	Domains          []string
+	LocalhostEnabled bool
+	namespace        string
+}
+
+func NewMTLSconfig(client client.Client, namespace string, domains []string, localhostEnabled bool) *TLSConfig {
+	config := &TLSConfig{
+		config:           nil,
+		client:           client,
+		Domains:          domains,
+		namespace:        namespace,
+		LocalhostEnabled: localhostEnabled,
+	}
+
+	// Secret providers here
+	secretProvider := NewCASecretProvider(client, namespace)
+	config.caProvider = append(config.caProvider, secretProvider)
+
+	return config
+}
+
+// @TODO mainly used for testing, maybe not needed at all
+func (conf *TLSConfig) SetCAProvider(caProviders []CAProvider) {
+	conf.caProvider = caProviders
+}
+
+func (conf *TLSConfig) InitCertificates() (*tls.Config, []*x509.Certificate, error) {
+	if len(conf.caProvider) == 0 {
+		return nil, nil, fmt.Errorf("No provider set")
+	}
+
+	var errors error
+	caCerts := []*CertificateGroup{}
+
+	CACertChain := []*x509.Certificate{}
+	caCertPool := x509.NewCertPool()
+
+	for _, caProvider := range conf.caProvider {
+		caCert, err := caProvider.GetCACertificate()
+		if err != nil {
+			errors = multierror.Append(errors, fmt.Errorf(
+				"cannot get CA certificate for provider %s: %v",
+				caProvider.GetName(), err))
+			continue
+		}
+
+		caCerts = append(caCerts, caCert)
+		CACertChain = append(CACertChain, caCert.GetCert())
+		caCertPool.AppendCertsFromPEM(caCert.certPEM.Bytes())
+	}
+
+	if errors != nil {
+		return nil, nil, errors
+	}
+
+	if len(caCerts) == 0 {
+		return nil, nil, fmt.Errorf("Cannot get any CA certificate")
+	}
+
+	// We always sign the certificates with the first CA server. I guess that it's normal
+	serverCert, err := getServerCertificate(conf.Domains, conf.LocalhostEnabled, caCerts[0])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certificate, err := serverCert.GetCertificate()
+	if err != nil {
+		return nil, nil, fmt.Errorf("Cannot create server certfificate: %v", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		ClientCAs:    caCertPool,
+		ClientAuth:   tls.RequireAnyClientCert,
+		MinVersion:   tls.VersionTLS13,
+	}
+	return tlsConfig, CACertChain, nil
+}
+
+func (conf *TLSConfig) CreateRegistrationClient() error {
+
+	name := fmt.Sprintf("%s-%s",
+		regClientSecretNamePrefix,
+		utilrand.String(regClientSecretNameRandomLen))
+
+	if len(conf.caProvider) == 0 {
+		return fmt.Errorf("Cannot get ca provider")
+	}
+
+	certData, err := conf.caProvider[0].CreateRegistrationCertificate(name)
+	if err != nil {
+		return fmt.Errorf("Cannot create client certificate")
+	}
+
+	secret := corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: conf.namespace,
+			Name:      name,
+			Labels:    map[string]string{regClientSecretLabelKey: "true"},
+		},
+		Data: certData,
+	}
+
+	return conf.client.Create(context.TODO(), &secret)
+}
+
+// isClientCertificateSigned is checking that PeerCertificates are signed by at
+// least one give CA certificate. The main reason to do this and not
+// x509.Certificate.Cert(certStore) is because is checking expiration time, and
+// for registration endpoint, we cannot assume that it'll be ok.
+func isClientCertificateSigned(PeerCertificates []*x509.Certificate, CAChain []*x509.Certificate) bool {
+	for _, cert := range PeerCertificates {
+		certValid := false
+		for _, caCert := range CAChain {
+			err := cert.CheckSignatureFrom(caCert)
+			// TODO log debug here with the error. Can be too verbose.
+			if err == nil {
+				certValid = true
+				break
+			}
+		}
+		if !certValid {
+			return false
+		}
+	}
+	return true
+}
+
+// VerifyRequest check certificate based on the scenario needed:
+// registration endpoint: Any cert signed, even if it's expired.
+// All endpoints: checking that it's valid certificate.
+// @TODO check here the list of rejected certificates.
+func VerifyRequest(r *http.Request, verifyType int, verifyOpts x509.VerifyOptions, CACertChain []*x509.Certificate) bool {
+
+	if len(r.TLS.PeerCertificates) == 0 {
+		return false
+	}
+
+	if verifyType == yggdrasil.YggdrasilRegisterAuth {
+		res := isClientCertificateSigned(r.TLS.PeerCertificates, CACertChain)
+		return res
+	}
+
+	valid := true
+	for _, cert := range r.TLS.PeerCertificates {
+		if cert.Subject.CommonName == certRegisterCN {
+			valid = false
+		}
+		if _, err := cert.Verify(verifyOpts); err != nil {
+			// TODO log debug here with the error. Can be too verbose.
+			return false
+		}
+	}
+	return valid
+}

--- a/internal/mtls/ca_test.go
+++ b/internal/mtls/ca_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"fmt"
 	"math/big"
 	"net"
 	"net/http"
@@ -43,7 +42,6 @@ var _ = Describe("CA test", func() {
 		)
 
 		BeforeEach(func() {
-			fmt.Println(namespace)
 			By("bootstrapping test environment")
 			testEnv = &envtest.Environment{
 				CRDDirectoryPaths: []string{
@@ -72,7 +70,7 @@ var _ = Describe("CA test", func() {
 
 		It("No namespace exists", func() {
 			// given
-			config := mtls.NewMTLSconfig(k8sClient, "falsy", []string{"foo.com"}, true)
+			config := mtls.NewMTLSConfig(k8sClient, "falsy", []string{"foo.com"}, true)
 
 			// when
 			tlsConfig, caChain, err := config.InitCertificates()
@@ -87,7 +85,7 @@ var _ = Describe("CA test", func() {
 
 		It("retrieve correctly", func() {
 			// given
-			config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, true)
+			config := mtls.NewMTLSConfig(k8sClient, namespace, dnsNames, true)
 
 			// when
 			tlsConfig, caChain, err := config.InitCertificates()
@@ -111,7 +109,7 @@ var _ = Describe("CA test", func() {
 
 		It("Server cert without localhost IPS", func() {
 			// given
-			config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, false)
+			config := mtls.NewMTLSConfig(k8sClient, namespace, dnsNames, false)
 
 			// when
 			tlsConfig, caChain, err := config.InitCertificates()
@@ -133,7 +131,7 @@ var _ = Describe("CA test", func() {
 
 		It("No CaProviders defined", func() {
 			// given
-			config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, false)
+			config := mtls.NewMTLSConfig(k8sClient, namespace, dnsNames, false)
 			config.SetCAProvider([]mtls.CAProvider{})
 
 			// when
@@ -163,7 +161,7 @@ var _ = Describe("CA test", func() {
 
 			It("Create cert", func() {
 				// given
-				config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, false)
+				config := mtls.NewMTLSConfig(k8sClient, namespace, dnsNames, false)
 				config.InitCertificates()
 
 				// when
@@ -176,7 +174,7 @@ var _ = Describe("CA test", func() {
 
 			It("Not valid CA set ", func() {
 				// given
-				config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, false)
+				config := mtls.NewMTLSConfig(k8sClient, namespace, dnsNames, false)
 				config.SetCAProvider([]mtls.CAProvider{})
 
 				// when
@@ -188,7 +186,7 @@ var _ = Describe("CA test", func() {
 
 			It("If ca not started return new one", func() {
 				// given
-				config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, false)
+				config := mtls.NewMTLSConfig(k8sClient, namespace, dnsNames, false)
 
 				// when
 				err := config.CreateRegistrationClientCerts()

--- a/internal/mtls/ca_test.go
+++ b/internal/mtls/ca_test.go
@@ -1,0 +1,508 @@
+package mtls_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/jakub-dzon/k4e-operator/internal/mtls"
+)
+
+const (
+	certRegisterCN = "register" // Important, make a copy here to prevent breaking changes
+)
+
+var _ = Describe("CA test", func() {
+
+	Context("TLSConfig", func() {
+
+		var (
+			k8sClient client.Client
+			namespace = "test"
+			testEnv   *envtest.Environment
+			dnsNames  = []string{"foo.com"}
+			ips       = []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
+		)
+
+		BeforeEach(func() {
+			fmt.Println(namespace)
+			By("bootstrapping test environment")
+			testEnv = &envtest.Environment{
+				CRDDirectoryPaths: []string{
+					filepath.Join("../..", "config", "crd", "bases"),
+					filepath.Join("../..", "config", "test", "crd"),
+				},
+				ErrorIfCRDPathMissing: true,
+			}
+			var err error
+			cfg, err := testEnv.Start()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg).NotTo(BeNil())
+
+			k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+			Expect(err).NotTo(HaveOccurred())
+
+			nsSpec := corev1.Namespace{ObjectMeta: v1.ObjectMeta{Name: namespace}}
+			err = k8sClient.Create(context.TODO(), &nsSpec)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err := testEnv.Stop()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("No namespace does not exists", func() {
+			// given
+			config := mtls.NewMTLSconfig(k8sClient, "falsy", []string{"foo.com"}, true)
+
+			// when
+			tlsConfig, caChain, err := config.InitCertificates()
+
+			// then
+			Expect(tlsConfig).To(BeNil())
+			Expect(caChain).To(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(
+				"1 error occurred:\n\t* cannot get CA certificate for provider secret: namespaces \"falsy\" not found\n\n"))
+		})
+
+		It("retrieve correctly", func() {
+			// given
+			config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, true)
+
+			// when
+			tlsConfig, caChain, err := config.InitCertificates()
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tlsConfig.Certificates).To(HaveLen(1))
+			Expect(tlsConfig.ClientAuth).To(Equal(tls.RequireAnyClientCert))
+			Expect(tlsConfig.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
+			Expect(caChain).To(HaveLen(1))
+
+			cert, err := x509.ParseCertificate(tlsConfig.Certificates[0].Certificate[0])
+			Expect(cert).NotTo(BeNil())
+			Expect(cert.SerialNumber).To(Equal(caChain[0].SerialNumber))
+			Expect(cert.Subject.CommonName).To(Equal("*"))
+			Expect(cert.DNSNames).To(Equal(dnsNames))
+			Expect(cert.IPAddresses).To(HaveLen(2))
+			Expect(cert.IPAddresses[0].To16()).To(Equal(ips[0].To16())) // IPV4 reflect issues.
+			Expect(cert.IPAddresses[1]).To(Equal(ips[1]))
+		})
+
+		It("Server cert without localhost IPS", func() {
+			// given
+			config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, false)
+
+			// when
+			tlsConfig, caChain, err := config.InitCertificates()
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tlsConfig.Certificates).To(HaveLen(1))
+			Expect(tlsConfig.ClientAuth).To(Equal(tls.RequireAnyClientCert))
+			Expect(tlsConfig.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
+			Expect(caChain).To(HaveLen(1))
+
+			cert, err := x509.ParseCertificate(tlsConfig.Certificates[0].Certificate[0])
+			Expect(cert).NotTo(BeNil())
+			Expect(cert.SerialNumber).To(Equal(caChain[0].SerialNumber))
+			Expect(cert.Subject.CommonName).To(Equal("*"))
+			Expect(cert.DNSNames).To(Equal(dnsNames))
+			Expect(cert.IPAddresses).To(HaveLen(0))
+		})
+
+		It("No CaProviders defined", func() {
+			// given
+			config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, false)
+			config.SetCAProvider([]mtls.CAProvider{})
+
+			// when
+			tlsConfig, caChain, err := config.InitCertificates()
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(tlsConfig).To(BeNil())
+			Expect(caChain).To(BeNil())
+		})
+
+		Context("Registration client", func() {
+
+			checkingOneSecret := func() {
+				options := client.ListOptions{
+					Namespace:     namespace,
+					LabelSelector: labels.Set{"reg-client-ca": "true"}.AsSelector(),
+				}
+				secrets := corev1.SecretList{}
+				err := k8sClient.List(context.TODO(), &secrets, &options)
+				ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Cannot get list secrets")
+
+				Expect(secrets.Items).To(HaveLen(1))
+				Expect(secrets.Items[0].Data).To(HaveKey("client.crt"))
+				Expect(secrets.Items[0].Data).To(HaveKey("client.key"))
+			}
+
+			It("Create cert", func() {
+				// given
+				config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, false)
+				config.InitCertificates()
+
+				// when
+				err := config.CreateRegistrationClient()
+
+				// then
+				Expect(err).NotTo(HaveOccurred())
+				checkingOneSecret()
+			})
+
+			It("Not valid CA set ", func() {
+				// given
+				config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, false)
+				config.SetCAProvider([]mtls.CAProvider{})
+
+				// when
+				err := config.CreateRegistrationClient()
+
+				// then
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("If ca not started return new one", func() {
+				// given
+				config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, false)
+
+				// when
+				err := config.CreateRegistrationClient()
+
+				// then
+				Expect(err).NotTo(HaveOccurred())
+				checkingOneSecret()
+			})
+		})
+	})
+
+	Context("VerifyRequest", func() {
+		var (
+			ca         []*certificate
+			CACertPool *x509.CertPool
+			CAChain    []*x509.Certificate
+			opts       x509.VerifyOptions
+		)
+
+		BeforeEach(func() {
+			ca = []*certificate{createCACert(), createCACert()}
+
+			CACertPool = x509.NewCertPool()
+			CAChain = []*x509.Certificate{}
+
+			for _, cert := range ca {
+				CACertPool.AddCert(cert.signedCert)
+				CAChain = append(CAChain, cert.signedCert)
+			}
+
+			opts = x509.VerifyOptions{
+				Roots:         CACertPool,
+				Intermediates: x509.NewCertPool(),
+			}
+		})
+
+		It("No peer certificates are present", func() {
+			// given
+			r := &http.Request{
+				TLS: &tls.ConnectionState{
+					PeerCertificates: []*x509.Certificate{},
+				},
+			}
+
+			// when
+			res := mtls.VerifyRequest(r, 0, opts, CAChain)
+
+			// then
+			Expect(res).To(BeFalse())
+		})
+
+		Context("Registration Auth", func() {
+			const (
+				AuthType = 1 // Equals to YggdrasilRegisterAuth, but it's important, so keep a copy here.
+			)
+
+			It("Peer certificate is valid", func() {
+				// given
+				cert := createRegistrationClientCert(ca[0])
+				r := &http.Request{
+					TLS: &tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{cert.signedCert},
+					},
+				}
+
+				// when
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+
+				// then
+				Expect(res).To(BeTrue())
+			})
+
+			It("Peer certificate is invalid", func() {
+				// given
+				cert := createRegistrationClientCert(createCACert())
+				r := &http.Request{
+					TLS: &tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{cert.signedCert},
+					},
+				}
+
+				// when
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+
+				// then
+				Expect(res).To(BeFalse())
+			})
+
+			It("Lastet CA certificate is valid", func() {
+				// given
+				cert := createRegistrationClientCert(ca[1])
+				r := &http.Request{
+					TLS: &tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{cert.signedCert},
+					},
+				}
+
+				// when
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+
+				// then
+				Expect(res).To(BeTrue())
+			})
+
+			It("Expired certificate is valid", func() {
+				// given
+				c := &x509.Certificate{
+					SerialNumber: big.NewInt(time.Now().Unix()),
+					Subject: pkix.Name{
+						Organization: []string{"K4e-operator"},
+					},
+					NotBefore:             time.Now(),
+					NotAfter:              time.Now().AddDate(0, 0, 0),
+					ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+					KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+					BasicConstraintsValid: true,
+				}
+
+				cert := createGivenClientCert(c, ca[1])
+				r := &http.Request{
+					TLS: &tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{cert.signedCert},
+					},
+				}
+
+				// when
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+
+				// then
+				Expect(res).To(BeTrue())
+			})
+
+		})
+
+		Context("Normal device Auth", func() {
+			const (
+				AuthType = 0 // Equals to YggdrasilCompleteAuth, but it's important, so keep a copy here.
+			)
+
+			It("Register certificate is invalid", func() {
+				// given
+				cert := createRegistrationClientCert(ca[0])
+				r := &http.Request{
+					TLS: &tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{cert.signedCert},
+					},
+				}
+
+				// when
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+
+				// then
+				Expect(res).To(BeFalse())
+			})
+
+			It("Certificate is correct", func() {
+				// given
+				cert := createClientCert(ca[0])
+				r := &http.Request{
+					TLS: &tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{cert.signedCert},
+					},
+				}
+
+				// when
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+
+				// then
+				Expect(res).To(BeTrue())
+			})
+
+			It("Invalid certificate is correct", func() {
+
+				// given
+				cert := createClientCert(createCACert())
+				r := &http.Request{
+					TLS: &tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{cert.signedCert},
+					},
+				}
+
+				// when
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+
+				// then
+				Expect(res).To(BeFalse())
+			})
+
+			It("Certificate valid with any CA position on the store.", func() {
+				// given
+				cert := createClientCert(ca[1])
+				r := &http.Request{
+					TLS: &tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{cert.signedCert},
+					},
+				}
+
+				// when
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+
+				// then
+				Expect(res).To(BeTrue())
+			})
+
+			It("Expired certificate is not working", func() {
+				// given
+				c := &x509.Certificate{
+					SerialNumber: big.NewInt(time.Now().Unix()),
+					Subject: pkix.Name{
+						Organization: []string{"K4e-operator"},
+						CommonName:   "test-device",
+					},
+					NotBefore:             time.Now(),
+					NotAfter:              time.Now().AddDate(0, 0, 0),
+					ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+					KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+					BasicConstraintsValid: true,
+				}
+				cert := createGivenClientCert(c, ca[0])
+
+				r := &http.Request{
+					TLS: &tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{cert.signedCert},
+					},
+				}
+
+				// when
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+
+				// then
+				Expect(res).To(BeFalse())
+			})
+
+		})
+
+	})
+})
+
+type certificate struct {
+	cert       *x509.Certificate
+	key        *rsa.PrivateKey
+	certBytes  []byte
+	signedCert *x509.Certificate
+}
+
+func createRegistrationClientCert(ca *certificate) *certificate {
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().Unix()),
+		Subject: pkix.Name{
+			Organization: []string{"K4e-operator"},
+			CommonName:   certRegisterCN,
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	return createGivenClientCert(cert, ca)
+}
+
+func createClientCert(ca *certificate) *certificate {
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().Unix()),
+		Subject: pkix.Name{
+			Organization: []string{"K4e-operator"},
+			CommonName:   "device-UUID",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	return createGivenClientCert(cert, ca)
+}
+
+func createGivenClientCert(cert *x509.Certificate, ca *certificate) *certificate {
+	certKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	ExpectWithOffset(1, err).To(BeNil(), "Fail on key generation")
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca.cert, &certKey.PublicKey, ca.key)
+	ExpectWithOffset(1, err).To(BeNil(), "Fail on sign generation")
+
+	signedCert, err := x509.ParseCertificate(certBytes)
+	ExpectWithOffset(1, err).To(BeNil(), "Fail on parsing certificate")
+
+	err = signedCert.CheckSignatureFrom(ca.signedCert)
+	ExpectWithOffset(1, err).To(BeNil(), "Fail on check signature")
+
+	return &certificate{cert, certKey, certBytes, signedCert}
+}
+
+func createCACert() *certificate {
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().Unix()),
+		Subject: pkix.Name{
+			Organization: []string{"K4e-operator"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	ExpectWithOffset(1, err).To(BeNil(), "Fail on key generation")
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	ExpectWithOffset(1, err).To(BeNil(), "Fail on sign generation")
+
+	signedCert, err := x509.ParseCertificate(caBytes)
+	ExpectWithOffset(1, err).To(BeNil(), "Fail on parsing certificate")
+
+	return &certificate{ca, caPrivKey, caBytes, signedCert}
+}

--- a/internal/mtls/ca_test.go
+++ b/internal/mtls/ca_test.go
@@ -70,7 +70,7 @@ var _ = Describe("CA test", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("No namespace does not exists", func() {
+		It("No namespace exists", func() {
 			// given
 			config := mtls.NewMTLSconfig(k8sClient, "falsy", []string{"foo.com"}, true)
 
@@ -167,7 +167,7 @@ var _ = Describe("CA test", func() {
 				config.InitCertificates()
 
 				// when
-				err := config.CreateRegistrationClient()
+				err := config.CreateRegistrationClientCerts()
 
 				// then
 				Expect(err).NotTo(HaveOccurred())
@@ -180,7 +180,7 @@ var _ = Describe("CA test", func() {
 				config.SetCAProvider([]mtls.CAProvider{})
 
 				// when
-				err := config.CreateRegistrationClient()
+				err := config.CreateRegistrationClientCerts()
 
 				// then
 				Expect(err).To(HaveOccurred())
@@ -191,7 +191,7 @@ var _ = Describe("CA test", func() {
 				config := mtls.NewMTLSconfig(k8sClient, namespace, dnsNames, false)
 
 				// when
-				err := config.CreateRegistrationClient()
+				err := config.CreateRegistrationClientCerts()
 
 				// then
 				Expect(err).NotTo(HaveOccurred())
@@ -277,7 +277,7 @@ var _ = Describe("CA test", func() {
 				Expect(res).To(BeFalse())
 			})
 
-			It("Lastet CA certificate is valid", func() {
+			It("Last CA certificate is valid", func() {
 				// given
 				cert := createRegistrationClientCert(ca[1])
 				r := &http.Request{
@@ -360,7 +360,7 @@ var _ = Describe("CA test", func() {
 				Expect(res).To(BeTrue())
 			})
 
-			It("Invalid certificate is correct", func() {
+			It("Invalid certificate is rejected", func() {
 
 				// given
 				cert := createClientCert(createCACert())

--- a/internal/mtls/caprovider_secret.go
+++ b/internal/mtls/caprovider_secret.go
@@ -1,0 +1,121 @@
+package mtls
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	CASecretName = "k4e-ca"
+	providerName = "secret"
+
+	caCertSecretKey     = "ca.key"
+	caCertCertKey       = "ca.crt"
+	clientCertSecretKey = "client.key"
+	clientCertCertKey   = "client.crt"
+
+	certOrganization       = "k4e-operator"
+	certRegisterCN         = "register"
+	certDefaultExpiration  = 1 // years
+	serverCertOrganization = "k4e-operator"
+)
+
+type CASecretProvider struct {
+	client    client.Client
+	namespace string
+}
+
+func NewCASecretProvider(client client.Client, namespace string) *CASecretProvider {
+	return &CASecretProvider{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+func (config *CASecretProvider) GetName() string {
+	return providerName
+}
+
+func (config *CASecretProvider) GetCACertificate() (*CertificateGroup, error) {
+	var secret corev1.Secret
+
+	err := config.client.Get(context.TODO(), client.ObjectKey{
+		Namespace: config.namespace,
+		Name:      CASecretName,
+	}, &secret)
+
+	if err == nil {
+		// Certificate is already created, parse it as *certificateGroup and return
+		// it
+		certGroup, err := NewCertificateGroupFromCACM(secret.Data)
+		return certGroup, err
+	}
+
+	if !errors.IsNotFound(err) {
+		return nil, err
+	}
+
+	certificateGroup, err := getCACertificate()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create sample certificate")
+	}
+
+	secret = corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: config.namespace,
+			Name:      CASecretName,
+		},
+		Data: map[string][]byte{
+			caCertCertKey:   certificateGroup.certPEM.Bytes(),
+			caCertSecretKey: certificateGroup.PrivKeyPEM.Bytes(),
+		},
+	}
+
+	err = config.client.Create(context.TODO(), &secret)
+	if err != nil {
+		return nil, err
+	}
+	return certificateGroup, err
+}
+
+func (config *CASecretProvider) CreateRegistrationCertificate(name string) (map[string][]byte, error) {
+	CACert, err := config.GetCACertificate()
+	if err != nil {
+		return nil, fmt.Errorf("Cannot retrieve caCert")
+	}
+
+	cert := &x509.Certificate{
+		SerialNumber: CACert.cert.SerialNumber,
+		Subject: pkix.Name{
+			CommonName:   certRegisterCN,
+			Organization: []string{certOrganization},
+			// Country:      []string{"US"},
+			SerialNumber: name,
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(certDefaultExpiration, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certGroup, err := getKeyAndCSR(cert, CACert)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot sign certificate request")
+	}
+	certGroup.CreatePem()
+
+	res := map[string][]byte{
+		clientCertCertKey:   certGroup.certPEM.Bytes(),
+		clientCertSecretKey: certGroup.PrivKeyPEM.Bytes(),
+	}
+	return res, nil
+}

--- a/internal/mtls/caprovider_secret.go
+++ b/internal/mtls/caprovider_secret.go
@@ -52,15 +52,15 @@ func (config *CASecretProvider) GetCACertificate() (*CertificateGroup, error) {
 		Name:      CASecretName,
 	}, &secret)
 
+	if !errors.IsNotFound(err) && err != nil {
+		return nil, err
+	}
+
 	if err == nil {
 		// Certificate is already created, parse it as *certificateGroup and return
 		// it
-		certGroup, err := NewCertificateGroupFromCACM(secret.Data)
+		certGroup, err := NewCertificateGroupFromSecret(secret.Data)
 		return certGroup, err
-	}
-
-	if !errors.IsNotFound(err) {
-		return nil, err
 	}
 
 	certificateGroup, err := getCACertificate()
@@ -97,7 +97,6 @@ func (config *CASecretProvider) CreateRegistrationCertificate(name string) (map[
 		Subject: pkix.Name{
 			CommonName:   certRegisterCN,
 			Organization: []string{certOrganization},
-			// Country:      []string{"US"},
 			SerialNumber: name,
 		},
 		NotBefore:    time.Now(),

--- a/internal/mtls/caprovider_secret.go
+++ b/internal/mtls/caprovider_secret.go
@@ -107,9 +107,9 @@ func (config *CASecretProvider) CreateRegistrationCertificate(name string) (map[
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
 
-	certGroup, err := getKeyAndCSR(cert, CACert)
+	certGroup, err := createKeyAndCSR(cert, CACert)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot sign certificate request")
+		return nil, fmt.Errorf("Cannot sign certificate request: %v", err)
 	}
 	certGroup.CreatePem()
 

--- a/internal/mtls/cert_utils.go
+++ b/internal/mtls/cert_utils.go
@@ -1,0 +1,174 @@
+package mtls
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+// CertificateGroup a bunch of methods to help to work with certificates.
+type CertificateGroup struct {
+	cert       *x509.Certificate
+	signedCert *x509.Certificate
+	privKey    *rsa.PrivateKey
+	certBytes  []byte
+	certPEM    *bytes.Buffer
+	PrivKeyPEM *bytes.Buffer
+}
+
+func NewCertificateGroupFromCACM(configMap map[string][]byte) (*CertificateGroup, error) {
+	certGroup := &CertificateGroup{
+		certPEM:    bytes.NewBuffer(configMap["ca.crt"]),
+		PrivKeyPEM: bytes.NewBuffer(configMap["ca.key"]),
+	}
+
+	block, _ := pem.Decode(certGroup.certPEM.Bytes())
+	if block == nil {
+		return nil, fmt.Errorf("Cannot get CA certificate")
+	}
+	ca, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("Failing parsing cert: %v", err)
+	}
+	block, _ = pem.Decode(certGroup.PrivKeyPEM.Bytes())
+	if block == nil {
+		return nil, fmt.Errorf("Cannot get CA certificate key")
+	}
+
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failing parsing key: %v", err)
+	}
+
+	certGroup.cert = ca // Not real at all, because this is already signed.
+	certGroup.signedCert = ca
+	certGroup.privKey = key
+	return certGroup, nil
+}
+
+// CreatePem from the load certificates create the PEM file and stores in local
+func (c *CertificateGroup) CreatePem() {
+
+	caPEM := new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: c.certBytes,
+	})
+
+	c.certPEM = caPEM
+
+	privKeyPEM := new(bytes.Buffer)
+	pem.Encode(privKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(c.privKey),
+	})
+	c.PrivKeyPEM = privKeyPEM
+}
+
+func (c *CertificateGroup) parseSignedCertificate() error {
+	var err error
+	c.signedCert, err = x509.ParseCertificate(c.certBytes)
+	return err
+}
+
+// GetCertificate returns the certificate Group in tls.Certficicate format.
+func (c *CertificateGroup) GetCertificate() (tls.Certificate, error) {
+	return tls.X509KeyPair(c.certPEM.Bytes(), c.PrivKeyPEM.Bytes())
+}
+
+func (c *CertificateGroup) GetCert() *x509.Certificate {
+	return c.cert
+}
+
+func getCACertificate() (*CertificateGroup, error) {
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().Unix()),
+		Subject: pkix.Name{
+			Organization: []string{"K4e-operator"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	// create our private and public key
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot generate CA Key")
+	}
+
+	// create the CA
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	certificateBundle := CertificateGroup{
+		cert:      ca,
+		privKey:   caPrivKey,
+		certBytes: caBytes,
+	}
+	certificateBundle.CreatePem()
+	certificateBundle.parseSignedCertificate()
+	return &certificateBundle, nil
+}
+
+func getKeyAndCSR(cert *x509.Certificate, caCert *CertificateGroup) (*CertificateGroup, error) {
+
+	certKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot generate cert Key")
+	}
+
+	// sign the cert by the CA
+	certBytes, err := x509.CreateCertificate(
+		rand.Reader, cert, caCert.cert, &certKey.PublicKey, caCert.privKey)
+	if err != nil {
+		return nil, err
+	}
+
+	certificateBundle := CertificateGroup{
+		cert:      cert,
+		privKey:   certKey,
+		certBytes: certBytes,
+	}
+	certificateBundle.CreatePem()
+	certificateBundle.parseSignedCertificate()
+	return &certificateBundle, nil
+}
+
+func getServerCertificate(dnsNames []string, localhostEnabled bool, CACert *CertificateGroup) (*CertificateGroup, error) {
+
+	ips := []net.IP{}
+	if localhostEnabled {
+		ips = append(ips, net.ParseIP("127.0.0.1"), net.ParseIP("::1"))
+	}
+
+	cert := &x509.Certificate{
+		SerialNumber: CACert.cert.SerialNumber,
+		Subject: pkix.Name{
+			CommonName:   "*", // CommonName match all, and using ASN names
+			Organization: []string{serverCertOrganization},
+			Country:      []string{"US"},
+		},
+		DNSNames:     dnsNames,
+		IPAddresses:  ips,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(certDefaultExpiration, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	return getKeyAndCSR(cert, CACert)
+}

--- a/internal/mtls/mtls_suite_test.go
+++ b/internal/mtls/mtls_suite_test.go
@@ -1,0 +1,13 @@
+package mtls_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMtls(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mtls Suite")
+}

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/jakub-dzon/k4e-operator/internal/images"
+
+	"net/http"
+	"net/url"
+	"strings"
+
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -14,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jakub-dzon/k4e-operator/api/v1alpha1"
 	"github.com/jakub-dzon/k4e-operator/internal/hardware"
+	"github.com/jakub-dzon/k4e-operator/internal/images"
 	"github.com/jakub-dzon/k4e-operator/internal/repository/edgedeployment"
 	"github.com/jakub-dzon/k4e-operator/internal/repository/edgedevice"
 	"github.com/jakub-dzon/k4e-operator/internal/storage"
@@ -29,8 +34,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const YggdrasilConnectionFinalizer = "yggdrasil-connection-finalizer"
-const YggdrasilWorkloadFinalizer = "yggdrasil-workload-finalizer"
+const (
+	YggdrasilConnectionFinalizer = "yggdrasil-connection-finalizer"
+	YggdrasilWorkloadFinalizer   = "yggdrasil-workload-finalizer"
+	YggdrasilRegisterAuth        = 1
+	YggdrasilCompleteAuth        = 0
+)
 
 var (
 	defaultHeartbeatConfiguration = models.HeartbeatConfiguration{
@@ -58,6 +67,24 @@ func NewYggdrasilHandler(deviceRepository edgedevice.Repository, deploymentRepos
 		recorder:               recorder,
 		registryAuthRepository: registryAuth,
 	}
+}
+
+func isRegisteredURL(url *url.URL) bool {
+	parts := strings.Split(url.Path, "/")
+	if len(parts) == 0 {
+		return false
+	}
+
+	last := parts[len(parts)-1]
+	return last == "registration"
+}
+
+func (h *Handler) SetAuthType(r *http.Request) int {
+	res := YggdrasilCompleteAuth
+	if isRegisteredURL(r.URL) {
+		res = YggdrasilRegisterAuth
+	}
+	return res
 }
 
 func (h *Handler) GetControlMessageForDevice(ctx context.Context, params yggdrasil.GetControlMessageForDeviceParams) middleware.Responder {

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -69,7 +69,7 @@ func NewYggdrasilHandler(deviceRepository edgedevice.Repository, deploymentRepos
 	}
 }
 
-func isRegisteredURL(url *url.URL) bool {
+func isRegistrationURL(url *url.URL) bool {
 	parts := strings.Split(url.Path, "/")
 	if len(parts) == 0 {
 		return false
@@ -79,9 +79,9 @@ func isRegisteredURL(url *url.URL) bool {
 	return last == "registration"
 }
 
-func (h *Handler) SetAuthType(r *http.Request) int {
+func (h *Handler) GetAuthType(r *http.Request) int {
 	res := YggdrasilCompleteAuth
-	if isRegisteredURL(r.URL) {
+	if isRegistrationURL(r.URL) {
 		res = YggdrasilRegisterAuth
 	}
 	return res

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ var Config struct {
 
 	// Domain where TLS certificate listen.
 	// FIXME check default here
-	Domain string `envconfig:"Domain" default:"k4e.com"`
+	Domain string `envconfig:"DOMAIN" default:"k4e.com"`
 
 	// If TLS server certificates should work on 127.0.0.1
 	TLSLocalhostEnabled bool `envconfig:"TLS_LOCALHOST_ENABLED" default:"true"`
@@ -219,7 +219,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		MTLSconfig := mtls.NewMTLSconfig(mgr.GetClient(), operatorNamespace,
+		MTLSconfig := mtls.NewMTLSConfig(mgr.GetClient(), operatorNamespace,
 			[]string{Config.Domain}, Config.TLSLocalhostEnabled)
 
 		tlsConfig, CACertChain, err := MTLSconfig.InitCertificates()
@@ -257,7 +257,7 @@ func main() {
 				// to renew client certificates, and because some devices can be
 				// disconnected for days and does not have the option to renew it.
 				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					authType := yggdrasilAPIHandler.SetAuthType(r)
+					authType := yggdrasilAPIHandler.GetAuthType(r)
 					if !mtls.VerifyRequest(r, authType, opts, CACertChain) {
 						w.WriteHeader(http.StatusUnauthorized)
 						return

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ var Config struct {
 	HttpPort uint16 `envconfig:"HTTP_PORT" default:"8888"`
 
 	// The port of the HTTPs server
-	HttpsPort uint16 `envconfig:"HTTP_PORT" default:"8443"`
+	HttpsPort uint16 `envconfig:"HTTP_PORT" default:"8043"`
 
 	// Domain where TLS certificate listen.
 	// FIXME check default here
@@ -229,7 +229,7 @@ func main() {
 		}
 
 		// @TODO check here what to do with leftovers or if a new one is need to be created
-		err = MTLSconfig.CreateRegistrationClient()
+		err = MTLSconfig.CreateRegistrationClientCerts()
 		if err != nil {
 			setupLog.Error(err, "Cannot create registration client certificate")
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -18,27 +18,25 @@ package main
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
-
-	"github.com/jakub-dzon/k4e-operator/internal/images"
-
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"strings"
 
-	"github.com/go-logr/logr"
-	"github.com/jakub-dzon/k4e-operator/internal/storage"
-	routev1 "github.com/openshift/api/route/v1"
-	"go.uber.org/zap/zapcore"
-
+	"github.com/jakub-dzon/k4e-operator/internal/images"
+	"github.com/jakub-dzon/k4e-operator/internal/mtls"
 	"github.com/jakub-dzon/k4e-operator/internal/repository/edgedeployment"
 	"github.com/jakub-dzon/k4e-operator/internal/repository/edgedevice"
+	"github.com/jakub-dzon/k4e-operator/internal/storage"
 	"github.com/jakub-dzon/k4e-operator/internal/yggdrasil"
 	"github.com/jakub-dzon/k4e-operator/restapi"
 	watchers "github.com/jakub-dzon/k4e-operator/watchers"
 	"github.com/kelseyhightower/envconfig"
+	routev1 "github.com/openshift/api/route/v1"
+	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -72,12 +70,28 @@ const (
 
 var (
 	scheme   = runtime.NewScheme()
-	setupLog logr.Logger
+	setupLog = ctrl.Log.WithName("setup")
+
+	// @TODO read /var/run/secrets/kubernetes.io/serviceaccount/namespace to get
+	// the correct namespace if it's installed in k8s
+	operatorNamespace = "k4e-operator-system"
 )
 
 var Config struct {
+
+	// NOTE DEPRECATE
 	// The port of the HTTP server
 	HttpPort uint16 `envconfig:"HTTP_PORT" default:"8888"`
+
+	// The port of the HTTPs server
+	HttpsPort uint16 `envconfig:"HTTP_PORT" default:"8443"`
+
+	// Domain where TLS certificate listen.
+	// FIXME check default here
+	Domain string `envconfig:"Domain" default:"k4e.com"`
+
+	// If TLS server certificates should work on 127.0.0.1
+	TLSLocalhostEnabled bool `envconfig:"TLS_LOCALHOST_ENABLED" default:"true"`
 
 	// The address the metric endpoint binds to.
 	MetricsAddr string `envconfig:"METRICS_ADDR" default:":8080"`
@@ -197,19 +211,75 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
-
+	registryAuth := images.NewRegistryAuth(mgr.GetClient())
 	go func() {
-		registryAuth := images.NewRegistryAuth(mgr.GetClient())
+
+		if !mgr.GetCache().WaitForCacheSync(context.TODO()) {
+			setupLog.Error(err, "Cache cannot start")
+			os.Exit(1)
+		}
+
+		MTLSconfig := mtls.NewMTLSconfig(mgr.GetClient(), operatorNamespace,
+			[]string{Config.Domain}, Config.TLSLocalhostEnabled)
+
+		tlsConfig, CACertChain, err := MTLSconfig.InitCertificates()
+		if err != nil {
+			setupLog.Error(err, "Cannot retrieve any MTLS configuration")
+			os.Exit(1)
+		}
+
+		// @TODO check here what to do with leftovers or if a new one is need to be created
+		err = MTLSconfig.CreateRegistrationClient()
+		if err != nil {
+			setupLog.Error(err, "Cannot create registration client certificate")
+			os.Exit(1)
+		}
+
+		opts := x509.VerifyOptions{
+			Roots:         tlsConfig.ClientCAs,
+			Intermediates: x509.NewCertPool(),
+		}
+
+		yggdrasilAPIHandler := yggdrasil.NewYggdrasilHandler(
+			edgeDeviceRepository,
+			edgeDeploymentRepository,
+			claimer,
+			initialDeviceNamespace,
+			mgr.GetEventRecorderFor("edgedeployment-controller"),
+			registryAuth)
+
 		h, err := restapi.Handler(restapi.Config{
-			YggdrasilAPI: yggdrasil.NewYggdrasilHandler(edgeDeviceRepository, edgeDeploymentRepository, claimer,
-				initialDeviceNamespace, mgr.GetEventRecorderFor("edgedeployment-controller"), registryAuth),
+			YggdrasilAPI: yggdrasilAPIHandler,
+			InnerMiddleware: func(h http.Handler) http.Handler {
+				// This is needed for one reason. Registration endpoint can be
+				// triggered with a certificate signed by the CA, but can be expired
+				// The main reason to allow expired certificates in this endpoint, it's
+				// to renew client certificates, and because some devices can be
+				// disconnected for days and does not have the option to renew it.
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					authType := yggdrasilAPIHandler.SetAuthType(r)
+					if !mtls.VerifyRequest(r, authType, opts, CACertChain) {
+						w.WriteHeader(http.StatusUnauthorized)
+						return
+					}
+					h.ServeHTTP(w, r)
+				})
+			},
 		})
+
 		if err != nil {
 			setupLog.Error(err, "cannot start http server")
 		}
-		address := fmt.Sprintf(":%v", Config.HttpPort)
-		setupLog.Info("starting http server", "address", address)
-		log.Fatal(http.ListenAndServe(address, h))
+
+		//@TODO This is a hack to keep compatibility now, to be deleted.
+		go http.ListenAndServe(fmt.Sprintf(":%v", Config.HttpPort), h)
+
+		server := &http.Server{
+			Addr:      fmt.Sprintf(":%v", Config.HttpsPort),
+			TLSConfig: tlsConfig,
+			Handler:   h,
+		}
+		log.Fatal(server.ListenAndServeTLS("", ""))
 	}()
 
 	if isInCluster() {

--- a/vendor/github.com/hashicorp/errwrap/LICENSE
+++ b/vendor/github.com/hashicorp/errwrap/LICENSE
@@ -1,0 +1,354 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+
+     means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of version
+        1.1 or earlier of the License, but not also under the terms of a
+        Secondary License.
+
+1.6. “Executable Form”
+
+     means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+
+     means a work that combines Covered Software with other material, in a separate
+     file or files, that is not Covered Software.
+
+1.8. “License”
+
+     means this document.
+
+1.9. “Licensable”
+
+     means having the right to grant, to the maximum extent possible, whether at the
+     time of the initial grant or subsequently, any and all of the rights conveyed by
+     this License.
+
+1.10. “Modifications”
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to, deletion
+        from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+
+      means any patent claim(s), including without limitation, method, process,
+      and apparatus claims, in any patent Licensable by such Contributor that
+      would be infringed, but for the grant of the License, by the making,
+      using, selling, offering for sale, having made, import, or transfer of
+      either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+
+      means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, “You” includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, “control” means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or as
+        part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its Contributions
+        or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution become
+     effective for each Contribution on the date the Contributor first distributes
+     such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under this
+     License. No additional rights or licenses will be implied from the distribution
+     or licensing of Covered Software under this License. Notwithstanding Section
+     2.1(b) above, no patent license is granted by a Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party’s
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or
+     logos of any Contributor (except as may be necessary to comply with the
+     notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this License
+     (see Section 10.2) or under the terms of a Secondary License (if permitted
+     under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its Contributions
+     are its original creation(s) or it has sufficient rights to grant the
+     rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under applicable
+     copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under the
+     terms of this License. You must inform recipients that the Source Code Form
+     of the Covered Software is governed by the terms of this License, and how
+     they can obtain a copy of this License. You may not attempt to alter or
+     restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this License,
+        or sublicense it under different terms, provided that the license for
+        the Executable Form does not attempt to limit or alter the recipients’
+        rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for the
+     Covered Software. If the Larger Work is a combination of Covered Software
+     with a work governed by one or more Secondary Licenses, and the Covered
+     Software is not Incompatible With Secondary Licenses, this License permits
+     You to additionally distribute such Covered Software under the terms of
+     such Secondary License(s), so that the recipient of the Larger Work may, at
+     their option, further distribute the Covered Software under the terms of
+     either this License or such Secondary License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices (including
+     copyright notices, patent notices, disclaimers of warranty, or limitations
+     of liability) contained within the Source Code Form of the Covered
+     Software, except that You may alter any license notices to the extent
+     required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on behalf
+     of any Contributor. You must make it absolutely clear that any such
+     warranty, support, indemnity, or liability obligation is offered by You
+     alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute, judicial
+   order, or regulation then You must: (a) comply with the terms of this License
+   to the maximum extent possible; and (b) describe the limitations and the code
+   they affect. Such description must be placed in a text file included with all
+   distributions of the Covered Software under this License. Except to the
+   extent prohibited by statute or regulation, such description must be
+   sufficiently detailed for a recipient of ordinary skill to be able to
+   understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+     if such Contributor fails to notify You of the non-compliance by some
+     reasonable means prior to 60 days after You have come back into compliance.
+     Moreover, Your grants from a particular Contributor are reinstated on an
+     ongoing basis if such Contributor notifies You of the non-compliance by
+     some reasonable means, this is the first time You have received notice of
+     non-compliance with this License from such Contributor, and You become
+     compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions, counter-claims,
+     and cross-claims) alleging that a Contributor Version directly or
+     indirectly infringes any patent, then the rights granted to You by any and
+     all Contributors for the Covered Software under Section 2.1 of this License
+     shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an “as is” basis, without
+   warranty of any kind, either expressed, implied, or statutory, including,
+   without limitation, warranties that the Covered Software is free of defects,
+   merchantable, fit for a particular purpose or non-infringing. The entire
+   risk as to the quality and performance of the Covered Software is with You.
+   Should any Covered Software prove defective in any respect, You (not any
+   Contributor) assume the cost of any necessary servicing, repair, or
+   correction. This disclaimer of warranty constitutes an essential part of this
+   License. No use of  any Covered Software is authorized under this License
+   except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from such
+   party’s negligence to the extent applicable law prohibits such limitation.
+   Some jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of
+   a jurisdiction where the defendant maintains its principal place of business
+   and such litigation shall be governed by laws of that jurisdiction, without
+   reference to its conflict-of-law provisions. Nothing in this Section shall
+   prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. Any law or regulation which provides that the language of a
+   contract shall be construed against the drafter shall not be used to construe
+   this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of
+      the License under which You originally received the Covered Software, or
+      under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a modified
+      version of this License if you rename the license and remove any
+      references to the name of the license steward (except to note that such
+      modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+      If You choose to distribute Source Code Form that is Incompatible With
+      Secondary Licenses under the terms of this version of the License, the
+      notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+      This Source Code Form is “Incompatible
+      With Secondary Licenses”, as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/hashicorp/errwrap/README.md
+++ b/vendor/github.com/hashicorp/errwrap/README.md
@@ -1,0 +1,89 @@
+# errwrap
+
+`errwrap` is a package for Go that formalizes the pattern of wrapping errors
+and checking if an error contains another error.
+
+There is a common pattern in Go of taking a returned `error` value and
+then wrapping it (such as with `fmt.Errorf`) before returning it. The problem
+with this pattern is that you completely lose the original `error` structure.
+
+Arguably the _correct_ approach is that you should make a custom structure
+implementing the `error` interface, and have the original error as a field
+on that structure, such [as this example](http://golang.org/pkg/os/#PathError).
+This is a good approach, but you have to know the entire chain of possible
+rewrapping that happens, when you might just care about one.
+
+`errwrap` formalizes this pattern (it doesn't matter what approach you use
+above) by giving a single interface for wrapping errors, checking if a specific
+error is wrapped, and extracting that error.
+
+## Installation and Docs
+
+Install using `go get github.com/hashicorp/errwrap`.
+
+Full documentation is available at
+http://godoc.org/github.com/hashicorp/errwrap
+
+## Usage
+
+#### Basic Usage
+
+Below is a very basic example of its usage:
+
+```go
+// A function that always returns an error, but wraps it, like a real
+// function might.
+func tryOpen() error {
+	_, err := os.Open("/i/dont/exist")
+	if err != nil {
+		return errwrap.Wrapf("Doesn't exist: {{err}}", err)
+	}
+
+	return nil
+}
+
+func main() {
+	err := tryOpen()
+
+	// We can use the Contains helpers to check if an error contains
+	// another error. It is safe to do this with a nil error, or with
+	// an error that doesn't even use the errwrap package.
+	if errwrap.Contains(err, "does not exist") {
+		// Do something
+	}
+	if errwrap.ContainsType(err, new(os.PathError)) {
+		// Do something
+	}
+
+	// Or we can use the associated `Get` functions to just extract
+	// a specific error. This would return nil if that specific error doesn't
+	// exist.
+	perr := errwrap.GetType(err, new(os.PathError))
+}
+```
+
+#### Custom Types
+
+If you're already making custom types that properly wrap errors, then
+you can get all the functionality of `errwraps.Contains` and such by
+implementing the `Wrapper` interface with just one function. Example:
+
+```go
+type AppError {
+  Code ErrorCode
+  Err  error
+}
+
+func (e *AppError) WrappedErrors() []error {
+  return []error{e.Err}
+}
+```
+
+Now this works:
+
+```go
+err := &AppError{Err: fmt.Errorf("an error")}
+if errwrap.ContainsType(err, fmt.Errorf("")) {
+	// This will work!
+}
+```

--- a/vendor/github.com/hashicorp/errwrap/errwrap.go
+++ b/vendor/github.com/hashicorp/errwrap/errwrap.go
@@ -1,0 +1,169 @@
+// Package errwrap implements methods to formalize error wrapping in Go.
+//
+// All of the top-level functions that take an `error` are built to be able
+// to take any error, not just wrapped errors. This allows you to use errwrap
+// without having to type-check and type-cast everywhere.
+package errwrap
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+)
+
+// WalkFunc is the callback called for Walk.
+type WalkFunc func(error)
+
+// Wrapper is an interface that can be implemented by custom types to
+// have all the Contains, Get, etc. functions in errwrap work.
+//
+// When Walk reaches a Wrapper, it will call the callback for every
+// wrapped error in addition to the wrapper itself. Since all the top-level
+// functions in errwrap use Walk, this means that all those functions work
+// with your custom type.
+type Wrapper interface {
+	WrappedErrors() []error
+}
+
+// Wrap defines that outer wraps inner, returning an error type that
+// can be cleanly used with the other methods in this package, such as
+// Contains, GetAll, etc.
+//
+// This function won't modify the error message at all (the outer message
+// will be used).
+func Wrap(outer, inner error) error {
+	return &wrappedError{
+		Outer: outer,
+		Inner: inner,
+	}
+}
+
+// Wrapf wraps an error with a formatting message. This is similar to using
+// `fmt.Errorf` to wrap an error. If you're using `fmt.Errorf` to wrap
+// errors, you should replace it with this.
+//
+// format is the format of the error message. The string '{{err}}' will
+// be replaced with the original error message.
+func Wrapf(format string, err error) error {
+	outerMsg := "<nil>"
+	if err != nil {
+		outerMsg = err.Error()
+	}
+
+	outer := errors.New(strings.Replace(
+		format, "{{err}}", outerMsg, -1))
+
+	return Wrap(outer, err)
+}
+
+// Contains checks if the given error contains an error with the
+// message msg. If err is not a wrapped error, this will always return
+// false unless the error itself happens to match this msg.
+func Contains(err error, msg string) bool {
+	return len(GetAll(err, msg)) > 0
+}
+
+// ContainsType checks if the given error contains an error with
+// the same concrete type as v. If err is not a wrapped error, this will
+// check the err itself.
+func ContainsType(err error, v interface{}) bool {
+	return len(GetAllType(err, v)) > 0
+}
+
+// Get is the same as GetAll but returns the deepest matching error.
+func Get(err error, msg string) error {
+	es := GetAll(err, msg)
+	if len(es) > 0 {
+		return es[len(es)-1]
+	}
+
+	return nil
+}
+
+// GetType is the same as GetAllType but returns the deepest matching error.
+func GetType(err error, v interface{}) error {
+	es := GetAllType(err, v)
+	if len(es) > 0 {
+		return es[len(es)-1]
+	}
+
+	return nil
+}
+
+// GetAll gets all the errors that might be wrapped in err with the
+// given message. The order of the errors is such that the outermost
+// matching error (the most recent wrap) is index zero, and so on.
+func GetAll(err error, msg string) []error {
+	var result []error
+
+	Walk(err, func(err error) {
+		if err.Error() == msg {
+			result = append(result, err)
+		}
+	})
+
+	return result
+}
+
+// GetAllType gets all the errors that are the same type as v.
+//
+// The order of the return value is the same as described in GetAll.
+func GetAllType(err error, v interface{}) []error {
+	var result []error
+
+	var search string
+	if v != nil {
+		search = reflect.TypeOf(v).String()
+	}
+	Walk(err, func(err error) {
+		var needle string
+		if err != nil {
+			needle = reflect.TypeOf(err).String()
+		}
+
+		if needle == search {
+			result = append(result, err)
+		}
+	})
+
+	return result
+}
+
+// Walk walks all the wrapped errors in err and calls the callback. If
+// err isn't a wrapped error, this will be called once for err. If err
+// is a wrapped error, the callback will be called for both the wrapper
+// that implements error as well as the wrapped error itself.
+func Walk(err error, cb WalkFunc) {
+	if err == nil {
+		return
+	}
+
+	switch e := err.(type) {
+	case *wrappedError:
+		cb(e.Outer)
+		Walk(e.Inner, cb)
+	case Wrapper:
+		cb(err)
+
+		for _, err := range e.WrappedErrors() {
+			Walk(err, cb)
+		}
+	default:
+		cb(err)
+	}
+}
+
+// wrappedError is an implementation of error that has both the
+// outer and inner errors.
+type wrappedError struct {
+	Outer error
+	Inner error
+}
+
+func (w *wrappedError) Error() string {
+	return w.Outer.Error()
+}
+
+func (w *wrappedError) WrappedErrors() []error {
+	return []error{w.Outer, w.Inner}
+}

--- a/vendor/github.com/hashicorp/errwrap/go.mod
+++ b/vendor/github.com/hashicorp/errwrap/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/errwrap

--- a/vendor/github.com/hashicorp/go-multierror/.travis.yml
+++ b/vendor/github.com/hashicorp/go-multierror/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+
+language: go
+
+go:
+  - 1.x
+
+branches:
+  only:
+    - master
+
+script: make test testrace

--- a/vendor/github.com/hashicorp/go-multierror/LICENSE
+++ b/vendor/github.com/hashicorp/go-multierror/LICENSE
@@ -1,0 +1,353 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+
+     means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of version
+        1.1 or earlier of the License, but not also under the terms of a
+        Secondary License.
+
+1.6. “Executable Form”
+
+     means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+
+     means a work that combines Covered Software with other material, in a separate
+     file or files, that is not Covered Software.
+
+1.8. “License”
+
+     means this document.
+
+1.9. “Licensable”
+
+     means having the right to grant, to the maximum extent possible, whether at the
+     time of the initial grant or subsequently, any and all of the rights conveyed by
+     this License.
+
+1.10. “Modifications”
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to, deletion
+        from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+
+      means any patent claim(s), including without limitation, method, process,
+      and apparatus claims, in any patent Licensable by such Contributor that
+      would be infringed, but for the grant of the License, by the making,
+      using, selling, offering for sale, having made, import, or transfer of
+      either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+
+      means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, “You” includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, “control” means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or as
+        part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its Contributions
+        or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution become
+     effective for each Contribution on the date the Contributor first distributes
+     such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under this
+     License. No additional rights or licenses will be implied from the distribution
+     or licensing of Covered Software under this License. Notwithstanding Section
+     2.1(b) above, no patent license is granted by a Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party’s
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or
+     logos of any Contributor (except as may be necessary to comply with the
+     notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this License
+     (see Section 10.2) or under the terms of a Secondary License (if permitted
+     under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its Contributions
+     are its original creation(s) or it has sufficient rights to grant the
+     rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under applicable
+     copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under the
+     terms of this License. You must inform recipients that the Source Code Form
+     of the Covered Software is governed by the terms of this License, and how
+     they can obtain a copy of this License. You may not attempt to alter or
+     restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this License,
+        or sublicense it under different terms, provided that the license for
+        the Executable Form does not attempt to limit or alter the recipients’
+        rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for the
+     Covered Software. If the Larger Work is a combination of Covered Software
+     with a work governed by one or more Secondary Licenses, and the Covered
+     Software is not Incompatible With Secondary Licenses, this License permits
+     You to additionally distribute such Covered Software under the terms of
+     such Secondary License(s), so that the recipient of the Larger Work may, at
+     their option, further distribute the Covered Software under the terms of
+     either this License or such Secondary License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices (including
+     copyright notices, patent notices, disclaimers of warranty, or limitations
+     of liability) contained within the Source Code Form of the Covered
+     Software, except that You may alter any license notices to the extent
+     required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on behalf
+     of any Contributor. You must make it absolutely clear that any such
+     warranty, support, indemnity, or liability obligation is offered by You
+     alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute, judicial
+   order, or regulation then You must: (a) comply with the terms of this License
+   to the maximum extent possible; and (b) describe the limitations and the code
+   they affect. Such description must be placed in a text file included with all
+   distributions of the Covered Software under this License. Except to the
+   extent prohibited by statute or regulation, such description must be
+   sufficiently detailed for a recipient of ordinary skill to be able to
+   understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+     if such Contributor fails to notify You of the non-compliance by some
+     reasonable means prior to 60 days after You have come back into compliance.
+     Moreover, Your grants from a particular Contributor are reinstated on an
+     ongoing basis if such Contributor notifies You of the non-compliance by
+     some reasonable means, this is the first time You have received notice of
+     non-compliance with this License from such Contributor, and You become
+     compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions, counter-claims,
+     and cross-claims) alleging that a Contributor Version directly or
+     indirectly infringes any patent, then the rights granted to You by any and
+     all Contributors for the Covered Software under Section 2.1 of this License
+     shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an “as is” basis, without
+   warranty of any kind, either expressed, implied, or statutory, including,
+   without limitation, warranties that the Covered Software is free of defects,
+   merchantable, fit for a particular purpose or non-infringing. The entire
+   risk as to the quality and performance of the Covered Software is with You.
+   Should any Covered Software prove defective in any respect, You (not any
+   Contributor) assume the cost of any necessary servicing, repair, or
+   correction. This disclaimer of warranty constitutes an essential part of this
+   License. No use of  any Covered Software is authorized under this License
+   except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from such
+   party’s negligence to the extent applicable law prohibits such limitation.
+   Some jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of
+   a jurisdiction where the defendant maintains its principal place of business
+   and such litigation shall be governed by laws of that jurisdiction, without
+   reference to its conflict-of-law provisions. Nothing in this Section shall
+   prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. Any law or regulation which provides that the language of a
+   contract shall be construed against the drafter shall not be used to construe
+   this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of
+      the License under which You originally received the Covered Software, or
+      under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a modified
+      version of this License if you rename the license and remove any
+      references to the name of the license steward (except to note that such
+      modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+      If You choose to distribute Source Code Form that is Incompatible With
+      Secondary Licenses under the terms of this version of the License, the
+      notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+      This Source Code Form is “Incompatible
+      With Secondary Licenses”, as defined by
+      the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/hashicorp/go-multierror/Makefile
+++ b/vendor/github.com/hashicorp/go-multierror/Makefile
@@ -1,0 +1,31 @@
+TEST?=./...
+
+default: test
+
+# test runs the test suite and vets the code.
+test: generate
+	@echo "==> Running tests..."
+	@go list $(TEST) \
+		| grep -v "/vendor/" \
+		| xargs -n1 go test -timeout=60s -parallel=10 ${TESTARGS}
+
+# testrace runs the race checker
+testrace: generate
+	@echo "==> Running tests (race)..."
+	@go list $(TEST) \
+		| grep -v "/vendor/" \
+		| xargs -n1 go test -timeout=60s -race ${TESTARGS}
+
+# updatedeps installs all the dependencies needed to run and build.
+updatedeps:
+	@sh -c "'${CURDIR}/scripts/deps.sh' '${NAME}'"
+
+# generate runs `go generate` to build the dynamically generated source files.
+generate:
+	@echo "==> Generating..."
+	@find . -type f -name '.DS_Store' -delete
+	@go list ./... \
+		| grep -v "/vendor/" \
+		| xargs -n1 go generate
+
+.PHONY: default test testrace updatedeps generate

--- a/vendor/github.com/hashicorp/go-multierror/README.md
+++ b/vendor/github.com/hashicorp/go-multierror/README.md
@@ -1,0 +1,97 @@
+# go-multierror
+
+[![Build Status](http://img.shields.io/travis/hashicorp/go-multierror.svg?style=flat-square)][travis]
+[![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)][godocs]
+
+[travis]: https://travis-ci.org/hashicorp/go-multierror
+[godocs]: https://godoc.org/github.com/hashicorp/go-multierror
+
+`go-multierror` is a package for Go that provides a mechanism for
+representing a list of `error` values as a single `error`.
+
+This allows a function in Go to return an `error` that might actually
+be a list of errors. If the caller knows this, they can unwrap the
+list and access the errors. If the caller doesn't know, the error
+formats to a nice human-readable format.
+
+`go-multierror` implements the
+[errwrap](https://github.com/hashicorp/errwrap) interface so that it can
+be used with that library, as well.
+
+## Installation and Docs
+
+Install using `go get github.com/hashicorp/go-multierror`.
+
+Full documentation is available at
+http://godoc.org/github.com/hashicorp/go-multierror
+
+## Usage
+
+go-multierror is easy to use and purposely built to be unobtrusive in
+existing Go applications/libraries that may not be aware of it.
+
+**Building a list of errors**
+
+The `Append` function is used to create a list of errors. This function
+behaves a lot like the Go built-in `append` function: it doesn't matter
+if the first argument is nil, a `multierror.Error`, or any other `error`,
+the function behaves as you would expect.
+
+```go
+var result error
+
+if err := step1(); err != nil {
+	result = multierror.Append(result, err)
+}
+if err := step2(); err != nil {
+	result = multierror.Append(result, err)
+}
+
+return result
+```
+
+**Customizing the formatting of the errors**
+
+By specifying a custom `ErrorFormat`, you can customize the format
+of the `Error() string` function:
+
+```go
+var result *multierror.Error
+
+// ... accumulate errors here, maybe using Append
+
+if result != nil {
+	result.ErrorFormat = func([]error) string {
+		return "errors!"
+	}
+}
+```
+
+**Accessing the list of errors**
+
+`multierror.Error` implements `error` so if the caller doesn't know about
+multierror, it will work just fine. But if you're aware a multierror might
+be returned, you can use type switches to access the list of errors:
+
+```go
+if err := something(); err != nil {
+	if merr, ok := err.(*multierror.Error); ok {
+		// Use merr.Errors
+	}
+}
+```
+
+**Returning a multierror only if there are errors**
+
+If you build a `multierror.Error`, you can use the `ErrorOrNil` function
+to return an `error` implementation only if there are errors to return:
+
+```go
+var result *multierror.Error
+
+// ... accumulate errors here
+
+// Return the `error` only if errors were added to the multierror, otherwise
+// return nil since there are no errors.
+return result.ErrorOrNil()
+```

--- a/vendor/github.com/hashicorp/go-multierror/append.go
+++ b/vendor/github.com/hashicorp/go-multierror/append.go
@@ -1,0 +1,41 @@
+package multierror
+
+// Append is a helper function that will append more errors
+// onto an Error in order to create a larger multi-error.
+//
+// If err is not a multierror.Error, then it will be turned into
+// one. If any of the errs are multierr.Error, they will be flattened
+// one level into err.
+func Append(err error, errs ...error) *Error {
+	switch err := err.(type) {
+	case *Error:
+		// Typed nils can reach here, so initialize if we are nil
+		if err == nil {
+			err = new(Error)
+		}
+
+		// Go through each error and flatten
+		for _, e := range errs {
+			switch e := e.(type) {
+			case *Error:
+				if e != nil {
+					err.Errors = append(err.Errors, e.Errors...)
+				}
+			default:
+				if e != nil {
+					err.Errors = append(err.Errors, e)
+				}
+			}
+		}
+
+		return err
+	default:
+		newErrs := make([]error, 0, len(errs)+1)
+		if err != nil {
+			newErrs = append(newErrs, err)
+		}
+		newErrs = append(newErrs, errs...)
+
+		return Append(&Error{}, newErrs...)
+	}
+}

--- a/vendor/github.com/hashicorp/go-multierror/flatten.go
+++ b/vendor/github.com/hashicorp/go-multierror/flatten.go
@@ -1,0 +1,26 @@
+package multierror
+
+// Flatten flattens the given error, merging any *Errors together into
+// a single *Error.
+func Flatten(err error) error {
+	// If it isn't an *Error, just return the error as-is
+	if _, ok := err.(*Error); !ok {
+		return err
+	}
+
+	// Otherwise, make the result and flatten away!
+	flatErr := new(Error)
+	flatten(err, flatErr)
+	return flatErr
+}
+
+func flatten(err error, flatErr *Error) {
+	switch err := err.(type) {
+	case *Error:
+		for _, e := range err.Errors {
+			flatten(e, flatErr)
+		}
+	default:
+		flatErr.Errors = append(flatErr.Errors, err)
+	}
+}

--- a/vendor/github.com/hashicorp/go-multierror/format.go
+++ b/vendor/github.com/hashicorp/go-multierror/format.go
@@ -1,0 +1,27 @@
+package multierror
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrorFormatFunc is a function callback that is called by Error to
+// turn the list of errors into a string.
+type ErrorFormatFunc func([]error) string
+
+// ListFormatFunc is a basic formatter that outputs the number of errors
+// that occurred along with a bullet point list of the errors.
+func ListFormatFunc(es []error) string {
+	if len(es) == 1 {
+		return fmt.Sprintf("1 error occurred:\n\t* %s\n\n", es[0])
+	}
+
+	points := make([]string, len(es))
+	for i, err := range es {
+		points[i] = fmt.Sprintf("* %s", err)
+	}
+
+	return fmt.Sprintf(
+		"%d errors occurred:\n\t%s\n\n",
+		len(es), strings.Join(points, "\n\t"))
+}

--- a/vendor/github.com/hashicorp/go-multierror/go.mod
+++ b/vendor/github.com/hashicorp/go-multierror/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/go-multierror
+
+require github.com/hashicorp/errwrap v1.0.0

--- a/vendor/github.com/hashicorp/go-multierror/go.sum
+++ b/vendor/github.com/hashicorp/go-multierror/go.sum
@@ -1,0 +1,4 @@
+github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce h1:prjrVgOk2Yg6w+PflHoszQNLTUh4kaByUcEWM/9uin4=
+github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/vendor/github.com/hashicorp/go-multierror/multierror.go
+++ b/vendor/github.com/hashicorp/go-multierror/multierror.go
@@ -1,0 +1,51 @@
+package multierror
+
+import (
+	"fmt"
+)
+
+// Error is an error type to track multiple errors. This is used to
+// accumulate errors in cases and return them as a single "error".
+type Error struct {
+	Errors      []error
+	ErrorFormat ErrorFormatFunc
+}
+
+func (e *Error) Error() string {
+	fn := e.ErrorFormat
+	if fn == nil {
+		fn = ListFormatFunc
+	}
+
+	return fn(e.Errors)
+}
+
+// ErrorOrNil returns an error interface if this Error represents
+// a list of errors, or returns nil if the list of errors is empty. This
+// function is useful at the end of accumulation to make sure that the value
+// returned represents the existence of errors.
+func (e *Error) ErrorOrNil() error {
+	if e == nil {
+		return nil
+	}
+	if len(e.Errors) == 0 {
+		return nil
+	}
+
+	return e
+}
+
+func (e *Error) GoString() string {
+	return fmt.Sprintf("*%#v", *e)
+}
+
+// WrappedErrors returns the list of errors that this Error is wrapping.
+// It is an implementation of the errwrap.Wrapper interface so that
+// multierror.Error can be used with that library.
+//
+// This method is not safe to be called concurrently and is no different
+// than accessing the Errors field directly. It is implemented only to
+// satisfy the errwrap.Wrapper interface.
+func (e *Error) WrappedErrors() []error {
+	return e.Errors
+}

--- a/vendor/github.com/hashicorp/go-multierror/prefix.go
+++ b/vendor/github.com/hashicorp/go-multierror/prefix.go
@@ -1,0 +1,37 @@
+package multierror
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/errwrap"
+)
+
+// Prefix is a helper function that will prefix some text
+// to the given error. If the error is a multierror.Error, then
+// it will be prefixed to each wrapped error.
+//
+// This is useful to use when appending multiple multierrors
+// together in order to give better scoping.
+func Prefix(err error, prefix string) error {
+	if err == nil {
+		return nil
+	}
+
+	format := fmt.Sprintf("%s {{err}}", prefix)
+	switch err := err.(type) {
+	case *Error:
+		// Typed nils can reach here, so initialize if we are nil
+		if err == nil {
+			err = new(Error)
+		}
+
+		// Wrap each of the errors
+		for i, e := range err.Errors {
+			err.Errors[i] = errwrap.Wrapf(format, e)
+		}
+
+		return err
+	default:
+		return errwrap.Wrapf(format, err)
+	}
+}

--- a/vendor/github.com/hashicorp/go-multierror/sort.go
+++ b/vendor/github.com/hashicorp/go-multierror/sort.go
@@ -1,0 +1,16 @@
+package multierror
+
+// Len implements sort.Interface function for length
+func (err Error) Len() int {
+	return len(err.Errors)
+}
+
+// Swap implements sort.Interface function for swapping elements
+func (err Error) Swap(i, j int) {
+	err.Errors[i], err.Errors[j] = err.Errors[j], err.Errors[i]
+}
+
+// Less implements sort.Interface function for determining order
+func (err Error) Less(i, j int) bool {
+	return err.Errors[i].Error() < err.Errors[j].Error()
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,6 +107,11 @@ github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/jsonschema
 github.com/googleapis/gnostic/openapiv2
+# github.com/hashicorp/errwrap v1.0.0
+github.com/hashicorp/errwrap
+# github.com/hashicorp/go-multierror v1.0.0
+## explicit
+github.com/hashicorp/go-multierror
 # github.com/hashicorp/golang-lru v0.5.4
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
@@ -418,6 +423,7 @@ k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/strategicpatch


### PR DESCRIPTION
This commit introduces the following changes:

TLS Listening
==============

When the operator starts, it will try to search for a CA certificate on
the 'k4e-ca' secret, where it will retrieve the x509 cert and the RSA
key. It'll create a new ca-cert if it's not present.

The operator will create the server certificates with that CA cert and
start listening on port 8443 by default. DNS name can be retrieval via
config; by default is k4e.com.

To keep compatibility with the device-worker, the server stills listen
on the HTTP port.

Mutual TLS
===========

To use the API, now client certificates are required, and as defined in
the task, there are two kinds of scenarios:

- **Registered endpoint**: Where a client certificate must be used, if
  the cert is expired, it'll be able to register the device. We only
  check the given CA signed the client certificate.

- **Auth endpoint**: Where a valid client certificate is needed.

This is why certs are checked on each request.

What is missing:
----------------

- The revocation list, a new CR need to be created and check on
  `mtls.VerifyRequest` ECOPROJECT-218
- Register endpoint is not yet implemented, where need to sign given
  x509 certificates. ECOPROJECT-401
- AuthN is done, but Authz on yggdrasil.API need to be done, like
  deviceID matchs with certificate CN. ECOPROJECT-402
- Doc

Coverage:
----------
Coverage is in good shape, and I'm confident with it:

```
github.com/jakub-dzon/k4e-operator/internal/mtls/ca.go:44:			NewMTLSconfig			100.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/ca.go:61:			SetCAProvider			100.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/ca.go:65:			InitCertificates		88.5%
github.com/jakub-dzon/k4e-operator/internal/mtls/ca.go:118:			CreateRegistrationClient	87.5%
github.com/jakub-dzon/k4e-operator/internal/mtls/ca.go:149:			isClientCertificateSigned	100.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/ca.go:171:			VerifyRequest			100.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/caprovider_secret.go:36:	NewCASecretProvider		100.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/caprovider_secret.go:43:	GetName				100.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/caprovider_secret.go:47:	GetCACertificate		86.7%
github.com/jakub-dzon/k4e-operator/internal/mtls/caprovider_secret.go:89:	CreateRegistrationCertificate	80.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/cert_utils.go:27:		NewCertificateGroupFromCACM	76.5%
github.com/jakub-dzon/k4e-operator/internal/mtls/cert_utils.go:58:		CreatePem			100.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/cert_utils.go:76:		parseSignedCertificate		100.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/cert_utils.go:83:		GetCertificate			100.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/cert_utils.go:87:		GetCert				100.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/cert_utils.go:91:		getCACertificate		81.8%
github.com/jakub-dzon/k4e-operator/internal/mtls/cert_utils.go:127:		getKeyAndCSR			80.0%
github.com/jakub-dzon/k4e-operator/internal/mtls/cert_utils.go:151:		getServerCertificate		100.0%
```

Fix https://issues.redhat.com/browse/ECOPROJECT-400

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>