### PR TITLE
Remove index cache for edge deployment

### DIFF
--- a/internal/repository/edgedeployment/edgedeployment.go
+++ b/internal/repository/edgedeployment/edgedeployment.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/jakub-dzon/k4e-operator/api/v1alpha1"
-	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	_ "github.com/golang/mock/mockgen/model"
@@ -12,7 +11,6 @@ import (
 
 //go:generate mockgen -package=edgedeployment -destination=mock_edgedeployment.go . Repository
 type Repository interface {
-	ListForEdgeDevice(ctx context.Context, name string, namespace string) ([]v1alpha1.EdgeDeployment, error)
 	Read(ctx context.Context, name string, namespace string) (*v1alpha1.EdgeDeployment, error)
 	Patch(ctx context.Context, old, new *v1alpha1.EdgeDeployment) error
 	RemoveFinalizer(ctx context.Context, edgeDeployment *v1alpha1.EdgeDeployment, finalizer string) error
@@ -24,24 +22,6 @@ type CRRespository struct {
 
 func NewEdgeDeploymentRepository(client client.Client) *CRRespository {
 	return &CRRespository{client: client}
-}
-
-func (r *CRRespository) ListForEdgeDevice(ctx context.Context, name string, namespace string) ([]v1alpha1.EdgeDeployment, error) {
-	edl := v1alpha1.EdgeDeploymentList{}
-
-	selector, err := fields.ParseSelector("spec.device=" + name)
-	if err != nil {
-		return nil, err
-	}
-	options := client.ListOptions{
-		Namespace:     namespace,
-		FieldSelector: selector,
-	}
-	err = r.client.List(ctx, &edl, &options)
-	if err != nil {
-		return nil, err
-	}
-	return edl.Items, nil
 }
 
 func (r *CRRespository) Read(ctx context.Context, name string, namespace string) (*v1alpha1.EdgeDeployment, error) {

--- a/internal/repository/edgedeployment/mock_edgedeployment.go
+++ b/internal/repository/edgedeployment/mock_edgedeployment.go
@@ -35,21 +35,6 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 	return m.recorder
 }
 
-// ListForEdgeDevice mocks base method.
-func (m *MockRepository) ListForEdgeDevice(arg0 context.Context, arg1, arg2 string) ([]v1alpha1.EdgeDeployment, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListForEdgeDevice", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]v1alpha1.EdgeDeployment)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListForEdgeDevice indicates an expected call of ListForEdgeDevice.
-func (mr *MockRepositoryMockRecorder) ListForEdgeDevice(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListForEdgeDevice", reflect.TypeOf((*MockRepository)(nil).ListForEdgeDevice), arg0, arg1, arg2)
-}
-
 // Patch mocks base method.
 func (m *MockRepository) Patch(arg0 context.Context, arg1, arg2 *v1alpha1.EdgeDeployment) error {
 	m.ctrl.T.Helper()

--- a/main.go
+++ b/main.go
@@ -37,8 +37,6 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	routev1 "github.com/openshift/api/route/v1"
 	"go.uber.org/zap/zapcore"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -51,10 +49,8 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -164,15 +160,6 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
-	}
-
-	cache := mgr.GetCache()
-	indexFunc := func(obj client.Object) []string {
-		return []string{obj.(*managementv1alpha1.EdgeDeployment).Spec.Device}
-	}
-
-	if err := cache.IndexField(context.Background(), &managementv1alpha1.EdgeDeployment{}, "spec.device", indexFunc); err != nil {
-		panic(err)
 	}
 
 	edgeDeviceRepository := edgedevice.NewEdgeDeviceRepository(mgr.GetClient())


### PR DESCRIPTION
In one of the recent runs, the following exception appeared in log:
```
{"level":"error","ts":1639383631.8659341,"logger":"controller-runtime.manager.controller.edgedeployment","msg":"Could not wait for Cache to sync","reconciler group":"management.k4e.io","reconciler kind":"EdgeDeployment","error":"failed to wait for edgedeployment caches to sync: cache did not sync","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/workspace/vendor/github.com/go-logr/zapr/zapr.go:132\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.1\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:190\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:195\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:223\nsigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).startRunnable.func1\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/manager/internal.go:681"}
```

Since we're no longer using the method that enhanced the index-function on the cache, we can get rid it completely and ease some of the overhead for the cache.

Signed-off-by: Moti Asayag <masayag@redhat.com>