### PR TITLE
Namespace issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,12 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Default k4e-Operator  namespace
+K4E_OPERATOR_NAMESPACE ?= "k4e-operator-system"
+
+# Set quiet mode by default
+Q=@
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -124,6 +130,7 @@ build: generate fmt vet ## Build manager binary.
 	go build -mod=vendor -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
+	$(Q) kubectl create ns $(K4E_OPERATOR_NAMESPACE) 2> /dev/null || exit 0
 	OBC_AUTO_CREATE=false LOG_LEVEL=debug go run -mod=vendor ./main.go
 
 docker-build: test ## Build docker image with the manager.

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	routev1 "github.com/openshift/api/route/v1"
 	"go.uber.org/zap/zapcore"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -117,6 +118,12 @@ func init() {
 	utilruntime.Must(managementv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(obv1.AddToScheme(scheme))
 	utilruntime.Must(routev1.AddToScheme(scheme))
+
+	ns, err := getOperatorNamespace()
+	if err != nil {
+		log.Fatalf("Cannot get running namespace: %v", err)
+	}
+	operatorNamespace = ns
 	//+kubebuilder:scaffold:scheme
 }
 
@@ -272,11 +279,6 @@ func main() {
 		k8sClient, err := kubernetes.NewForConfig(mgr.GetConfig())
 		if err != nil {
 			setupLog.Error(err, "cannot get the k8s client set")
-			os.Exit(1)
-		}
-		operatorNamespace, err := getOperatorNamespace()
-		if err != nil {
-			setupLog.Error(err, "cannot get the operator namespace")
 			os.Exit(1)
 		}
 		setupLog.V(1).Info("operator namespace found", "operatorNamespace", operatorNamespace)


### PR DESCRIPTION
Hi, 

Two commits here:

1) main.go move operatorNamespace variable set on init phase. So always use the global var. @gciavarrini maybe I break something here. 
2) Makefile: add ns creation on make run to not fail on MTLS. 

Thanks. 