### PR TITLE
MTLS: Add CA sign method

### DIFF
--- a/internal/mtls/caprovider_secret.go
+++ b/internal/mtls/caprovider_secret.go
@@ -155,7 +155,7 @@ func (config *CASecretProvider) SignCSR(CSRPem string, commonName string, expira
 		PublicKey:          CSR.PublicKey,
 		SerialNumber:       big.NewInt(time.Now().Unix()),
 		Subject:            CSR.Subject,
-		NotBefore:          time.Now(),
+		NotBefore:          time.Now().AddDate(0, 0, -1), // 1 day before for time drift issues
 		NotAfter:           expiration,
 		KeyUsage:           x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},

--- a/main.go
+++ b/main.go
@@ -111,6 +111,9 @@ var Config struct {
 
 	// Number of concurrent goroutines to create for handling EdgeDeployment reconcile
 	EdgeDeploymentConcurrency uint `envconfig:"EDGEDEPLOYMENT_CONCURRENCY" default:"5"`
+
+	// Client Certificate expiration time
+	ClientCertExpirationTime uint `envconfig:"CLIENT_CERT_EXPIRATION_DAYS" default:"30"`
 }
 
 func init() {
@@ -215,6 +218,11 @@ func main() {
 
 		MTLSconfig := mtls.NewMTLSConfig(mgr.GetClient(), operatorNamespace,
 			[]string{Config.Domain}, Config.TLSLocalhostEnabled)
+
+		err = MTLSconfig.SetClientExpiration(int(Config.ClientCertExpirationTime))
+		if err != nil {
+			setupLog.Error(err, "Cannot set MTLS client certificate expiration time")
+		}
 
 		tlsConfig, CACertChain, err := MTLSconfig.InitCertificates()
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -216,22 +216,22 @@ func main() {
 			os.Exit(1)
 		}
 
-		MTLSconfig := mtls.NewMTLSConfig(mgr.GetClient(), operatorNamespace,
+		mtlsConfig := mtls.NewMTLSConfig(mgr.GetClient(), operatorNamespace,
 			[]string{Config.Domain}, Config.TLSLocalhostEnabled)
 
-		err = MTLSconfig.SetClientExpiration(int(Config.ClientCertExpirationTime))
+		err = mtlsConfig.SetClientExpiration(int(Config.ClientCertExpirationTime))
 		if err != nil {
 			setupLog.Error(err, "Cannot set MTLS client certificate expiration time")
 		}
 
-		tlsConfig, CACertChain, err := MTLSconfig.InitCertificates()
+		tlsConfig, CACertChain, err := mtlsConfig.InitCertificates()
 		if err != nil {
 			setupLog.Error(err, "Cannot retrieve any MTLS configuration")
 			os.Exit(1)
 		}
 
 		// @TODO check here what to do with leftovers or if a new one is need to be created
-		err = MTLSconfig.CreateRegistrationClientCerts()
+		err = mtlsConfig.CreateRegistrationClientCerts()
 		if err != nil {
 			setupLog.Error(err, "Cannot create registration client certificate")
 			os.Exit(1)


### PR DESCRIPTION
This is a commit that implements the Sign method to be used on the
registration API endpoint.

It receives a Certificate Signed Request and sign and return a x509
Certificate signed by the first CA authority.

This PR is part of: ECOPROJECT-401

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>