### PR TITLE
Expose Operator's HTTP endpoint externally

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -65,6 +65,7 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../network
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -66,26 +66,6 @@ spec:
       protocol: TCP
       port: 8043
       targetPort: 8043
-    - name: metrics
-      protocol: TCP
-      port: 8080
-      targetPort: 8080
   selector:
     control-plane: controller-manager
   type: ClusterIP
----
-kind: ServiceMonitor
-apiVersion: monitoring.coreos.com/v1
-metadata:
-  name: servicemonitor
-  namespace: system
-  labels:
-    control-plane: controller-manager
-spec:
-  endpoints:
-    - port: metrics
-      interval: 30s
-      path: /metrics
-  selector:
-    matchLabels:
-      control-plane: controller-manager

--- a/config/network/ingress.yaml
+++ b/config/network/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: system
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - host: REPLACE_HOSTNAME
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: controller-manager
+                port:
+                  number: 8888

--- a/config/network/kustomization.yaml
+++ b/config/network/kustomization.yaml
@@ -1,0 +1,2 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/network/route.yaml
+++ b/config/network/route.yaml
@@ -1,0 +1,15 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager
+  namespace: system
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: controller-manager
+    weight: 100
+  wildcardPolicy: None


### PR DESCRIPTION
Create Ingress resource on make deploy, which will make HTTP endpoint accessible externally out-of-the-box and port-forwarding is not required.

On OpenShift cluster:
1. Deploy with `IMG=<image registry and tag> TARGET=ocp make deploy`.
2. Get HTTP server address by running:
`HTTP_SERVER=$(oc get routes k4e-operator-controller-manager -n k4e-operator-system --no-headers -o=custom-columns=HOST:.spec.host)`.
3. Start yggdrasil with host/port value from step 2: `sudo go run ./cmd/yggd --log-level info --transport http --cert-file /etc/pki/consumer/cert.pem --key-file /etc/pki/consumer/key.pem --client-id-source machine-id --http-server $HTTP_SERVER`.

On Minikube cluster:
1. Deploy with `IMG=<image registry and tag> HOST=<host name> TARGET=k8s make deploy`.
2. Add to `/etc/hosts`: `<minikube ip> <host name>`.
3. Start yggdrasil with from the yggdrasil repository directory: `sudo go run ./cmd/yggd --log-level info --transport http --cert-file /etc/pki/consumer/cert.pem --key-file /etc/pki/consumer/key.pem --client-id-source machine-id --http-server <host name>`.

If `HOST` isn't specified, the default value is `k4e-operator.srv`.
If `TARGET` isn't specified, the default value is `k8s`.