### PR TITLE
Update metrics service

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,7 +19,3 @@ spec:
         ports:
         - containerPort: 8443
           name: https
-      - name: manager
-        ports:
-          - containerPort: 8888
-            name: http

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,6 +32,13 @@ spec:
             name: manager-config
         image: controller:latest
         name: manager
+        ports:
+          - containerPort: 8888
+            name: http
+          - containerPort: 8043
+            name: https
+          - containerPort: 8080
+            name: metrics
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:
@@ -68,11 +75,11 @@ spec:
     - name: http
       protocol: TCP
       port: 8888
-      targetPort: 8888
+      targetPort: http
     - name: https
       protocol: TCP
       port: 8043
-      targetPort: 8043
+      targetPort: https
   selector:
     control-plane: controller-manager
   type: ClusterIP

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -10,5 +10,9 @@ spec:
   - name: https
     port: 8443
     targetPort: https
+  - name: http
+    protocol: TCP
+    port: 8080
+    targetPort: metrics
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
- Move metrics port from http-server service to metrics-service.
- Restore metrics port.
- Add to operator's deployment pod's ports.
- Use port name instead of port number in service to map service port to pod's target port

Signed-off-by: Moti Asayag <masayag@redhat.com>