### PR TITLE
Metrics: interval fix

### DIFF
--- a/api/v1alpha1/edgedeployment_types.go
+++ b/api/v1alpha1/edgedeployment_types.go
@@ -65,7 +65,7 @@ type ContainerMetricsConfiguration struct {
 	// Interval(in seconds) to scrape metrics endpoint.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:default=60
-	Interval int `json:"interval,omitempty"`
+	Interval int32 `json:"interval,omitempty"`
 
 	Containers map[string]*MetricsConfigEntity `json:"containers,omitempty"`
 }

--- a/config/crd/bases/management.k4e.io_edgedeployments.yaml
+++ b/config/crd/bases/management.k4e.io_edgedeployments.yaml
@@ -134,6 +134,7 @@ spec:
                   interval:
                     default: 60
                     description: Interval(in seconds) to scrape metrics endpoint.
+                    format: int32
                     minimum: 0
                     type: integer
                   path:

--- a/docs/design/http_api_swagger.md
+++ b/docs/design/http_api_swagger.md
@@ -631,7 +631,7 @@ Status: Internal Server Error
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | containers | map of [ContainerMetrics](#container-metrics)| `map[string]ContainerMetrics` |  | |  |  |
-| interval | integer| `int64` |  | | Interval(in seconds) to scrape metrics endpoint. |  |
+| interval | int32 (formatted integer)| `int32` |  | | Interval(in seconds) to scrape metrics endpoint. |  |
 | path | string| `string` |  | | Path to use when retrieving metrics |  |
 | port | int32 (formatted integer)| `int32` |  | |  |  |
 

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -425,8 +425,9 @@ func (h *Handler) toWorkloadList(ctx context.Context, logger logr.Logger, deploy
 
 		if spec.Metrics != nil && spec.Metrics.Port > 0 {
 			workload.Metrics = &models.Metrics{
-				Path: spec.Metrics.Path,
-				Port: spec.Metrics.Port,
+				Path:     spec.Metrics.Path,
+				Port:     spec.Metrics.Port,
+				Interval: int64(spec.Metrics.Interval),
 			}
 			addedContainers := false
 			containers := map[string]models.ContainerMetrics{}

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -427,7 +427,7 @@ func (h *Handler) toWorkloadList(ctx context.Context, logger logr.Logger, deploy
 			workload.Metrics = &models.Metrics{
 				Path:     spec.Metrics.Path,
 				Port:     spec.Metrics.Port,
-				Interval: int64(spec.Metrics.Interval),
+				Interval: spec.Metrics.Interval,
 			}
 			addedContainers := false
 			containers := map[string]models.ContainerMetrics{}

--- a/internal/yggdrasil/yggdrasil_test.go
+++ b/internal/yggdrasil/yggdrasil_test.go
@@ -480,16 +480,17 @@ var _ = Describe("Yggdrasil", func() {
 				}
 			}
 
-			It("Path and port is honored", func() {
+			It("Path, port and interval is honored", func() {
 				// given
 				expectedResult := &models.Metrics{
-					Path: "/metrics",
-					Port: 9999,
+					Path:     "/metrics",
+					Port:     9999,
+					Interval: 55,
 				}
 
 				deploy := getDeployment("workload1", testNamespace)
 				deploy.Spec.Metrics = &v1alpha1.ContainerMetricsConfiguration{
-					Path: "/metrics", Port: 9999}
+					Path: "/metrics", Port: 9999, Interval: 55}
 
 				deployRepoMock.EXPECT().
 					Read(gomock.Any(), "workload1", testNamespace).

--- a/models/metrics.go
+++ b/models/metrics.go
@@ -21,7 +21,7 @@ type Metrics struct {
 	Containers map[string]ContainerMetrics `json:"containers,omitempty"`
 
 	// Interval(in seconds) to scrape metrics endpoint.
-	Interval int64 `json:"interval,omitempty"`
+	Interval int32 `json:"interval,omitempty"`
 
 	// Path to use when retrieving metrics
 	Path string `json:"path,omitempty"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -651,7 +651,8 @@ func init() {
         },
         "interval": {
           "description": "Interval(in seconds) to scrape metrics endpoint.",
-          "type": "integer"
+          "type": "integer",
+          "format": "int32"
         },
         "path": {
           "description": "Path to use when retrieving metrics",
@@ -1473,7 +1474,8 @@ func init() {
         },
         "interval": {
           "description": "Interval(in seconds) to scrape metrics endpoint.",
-          "type": "integer"
+          "type": "integer",
+          "format": "int32"
         },
         "path": {
           "description": "Path to use when retrieving metrics",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -281,6 +281,7 @@ definitions:
         format: int32
       interval:
         type: integer
+        format: int32
         description: Interval(in seconds) to scrape metrics endpoint.
 
       containers:


### PR DESCRIPTION
On commit c68950ac273fdb6a9721efb4b5cd980b193a3c8f, the CRD.config was
translated to API response, but Metrics Interval was not translated at
all and device cannot retrieve the information correctly.

Related-to: ECOPROJECT-425

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>