### PR TITLE
Enable monitoring for OCP

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -72,4 +72,4 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    openshift.io/cluster-monitoring: "true"
   name: system
 ---
 apiVersion: apps/v1
@@ -34,9 +35,9 @@ spec:
         name: manager
         ports:
           - containerPort: 8888
-            name: http
+            name: yggd
           - containerPort: 8043
-            name: https
+            name: yggds
           - containerPort: 8080
             name: metrics
         securityContext:
@@ -72,14 +73,14 @@ metadata:
     control-plane: controller-manager
 spec:
   ports:
-    - name: http
+    - name: yggd
       protocol: TCP
       port: 8888
-      targetPort: http
-    - name: https
+      targetPort: yggd
+    - name: yggds
       protocol: TCP
       port: 8043
-      targetPort: https
+      targetPort: yggds
   selector:
     control-plane: controller-manager
   type: ClusterIP

--- a/config/network/route.yaml
+++ b/config/network/route.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: system
 spec:
   port:
-    targetPort: http
+    targetPort: yggd
   to:
     kind: Service
     name: k4e-operator-controller-manager

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,2 @@
-resources:
-- monitor.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,4 +1,3 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/config/prometheus/prometheus_role.yaml
+++ b/config/prometheus/prometheus_role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/prometheus/prometheus_role_binding.yaml
+++ b/config/prometheus/prometheus_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/docs/metrics/metrics.md
+++ b/docs/metrics/metrics.md
@@ -1,39 +1,16 @@
-# Publication of the metrics
+# Publication of the metrics in Prometheus on OCP
 
 In order to publish the metrics several steps need to be done:
-- Create a service monitor
-```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: k4e-operator-servicemonitor
-  namespace: k4e-operator-system
-  labels:
-    control-plane: controller-manager
-spec:
-  endpoints:
-    - port: metrics
-      interval: 30s
-      path: /metrics
-  selector:
-    matchLabels:
-      control-plane: controller-manager
-```
-- Add port 8080 to k4e-operator-controller-manager service
-```yaml
-    - name: metrics
-      protocol: TCP
-      port: 8080
-      targetPort: 8080
-```
-- Enable user-defined for user projects
-```yaml
+
+- Enable monitoring on the cluster
+```bash
+kubectl apply -f - <<EOF
 apiVersion: v1
-data:
-  config.yaml: |
-    enableUserWorkload: true
 kind: ConfigMap
 metadata:
   name: cluster-monitoring-config
   namespace: openshift-monitoring
+data:
+  config.yaml: |
+  EOF
 ``` 


### PR DESCRIPTION
The patch adds the missing resources to enable monitoring for k4e.
In addition, in order to avoid from collision due to services with the
same labels/selector and the same port name (https), the http server
ports were renamed to yggd and yddgs.
Alternately, the https port name of the metrics can be renamed.
Before this PR, the endpoints of two services was the same, while there
was no representation for the :8043 port.

```
→ oc get ep -n k4e-operator-system
NAME                                              ENDPOINTS                             AGE
k4e-operator-controller-manager                   172.30.0.151:8888,172.30.0.151:8443   2m10s
k4e-operator-controller-manager-metrics-service   172.30.0.151:8443,172.30.0.151:8080   2m10s
```

With this PR, all 4 ports are presented, according to the service:
```
→ oc get ep -n k4e-operator-system -o wide
NAME                                              ENDPOINTS                             AGE
k4e-operator-controller-manager                   172.30.0.158:8043,172.30.0.158:8888   50s
k4e-operator-controller-manager-metrics-service   172.30.0.158:8443,172.30.0.158:8080   50s

→ oc get svc -n k4e-operator-system -o wide
NAME                                              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE   SELECTOR
k4e-operator-controller-manager                   ClusterIP   10.128.171.232   <none>        8888/TCP,8043/TCP   61s   control-plane=controller-manager
k4e-operator-controller-manager-metrics-service   ClusterIP   10.128.104.37    <none>        8443/TCP,8080/TCP   61s   control-plane=controller-manager
```

This PR doesn't include the update required for enabling monitoring in OCP which can be done by running:
```
kubectl apply -f - <<EOF
apiVersion: v1
data:
  config.yaml: |
    enableUserWorkload: true
kind: ConfigMap
metadata:
  name: cluster-monitoring-config
  namespace: openshift-monitoring
EOF
```

Signed-off-by: Moti Asayag <masayag@redhat.com>