### PR TITLE
Update operator metrics

### DIFF
--- a/controllers/edgedevice_controller.go
+++ b/controllers/edgedevice_controller.go
@@ -109,7 +109,6 @@ func (r *EdgeDeviceReconciler) createOrGetObc(ctx context.Context, edgeDevice *m
 			logger.Error(err, "Cannot create object bucket claim for the device")
 			return nil, err
 		}
-		r.Metrics.IncCreatedOBCs()
 		return obc, nil
 	}
 

--- a/controllers/edgedevice_controller_test.go
+++ b/controllers/edgedevice_controller_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/jakub-dzon/k4e-operator/api/v1alpha1"
 	"github.com/jakub-dzon/k4e-operator/controllers"
-	"github.com/jakub-dzon/k4e-operator/internal/metrics"
 	"github.com/jakub-dzon/k4e-operator/internal/repository/edgedevice"
 	"github.com/jakub-dzon/k4e-operator/internal/storage"
 	obv1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
@@ -34,13 +33,11 @@ var _ = Describe("EdgeDevice controller", func() {
 
 		edgeDeviceRepoMock *edgedevice.MockRepository
 		k8sManager         manager.Manager
-		metricsMock        *metrics.MockMetrics
 	)
 
 	BeforeEach(func() {
 		k8sManager = getK8sManager(cfg)
 		mockCtrl := gomock.NewController(GinkgoT())
-		metricsMock = metrics.NewMockMetrics(mockCtrl)
 		edgeDeviceRepository := edgedevice.NewEdgeDeviceRepository(k8sClient)
 		edgeDeviceReconciler = &controllers.EdgeDeviceReconciler{
 			Client:               k8sClient,
@@ -48,7 +45,6 @@ var _ = Describe("EdgeDevice controller", func() {
 			EdgeDeviceRepository: edgeDeviceRepository,
 			Claimer:              storage.NewClaimer(k8sClient),
 			ObcAutoCreate:        false,
-			Metrics:              metricsMock,
 		}
 		err = edgeDeviceReconciler.SetupWithManager(k8sManager)
 		Expect(err).ToNot(HaveOccurred())
@@ -87,7 +83,6 @@ var _ = Describe("EdgeDevice controller", func() {
 				EdgeDeviceRepository: edgeDeviceRepoMock,
 				Claimer:              storage.NewClaimer(k8sClient),
 				ObcAutoCreate:        false,
-				Metrics:              metricsMock,
 			}
 		})
 
@@ -189,10 +184,6 @@ var _ = Describe("EdgeDevice controller", func() {
 				Return(fmt.Errorf("failed")).
 				Times(1)
 
-			metricsMock.EXPECT().
-				IncCreatedOBCs().
-				AnyTimes()
-
 			edgeDeviceReconciler.ObcAutoCreate = true
 
 			// when
@@ -221,10 +212,6 @@ var _ = Describe("EdgeDevice controller", func() {
 				Times(1)
 
 			edgeDeviceReconciler.ObcAutoCreate = true
-
-			metricsMock.EXPECT().
-				IncCreatedOBCs().
-				AnyTimes()
 
 			// when
 			res, err := edgeDeviceReconciler.Reconcile(context.TODO(), req)
@@ -284,10 +271,6 @@ var _ = Describe("EdgeDevice controller", func() {
 			},
 		}
 
-		metricsMock.EXPECT().
-			IncCreatedOBCs().
-			AnyTimes()
-
 		// when
 		err := k8sClient.Create(ctx, &edgeDevice)
 
@@ -331,10 +314,6 @@ var _ = Describe("EdgeDevice controller", func() {
 				},
 			},
 		}
-
-		metricsMock.EXPECT().
-			IncCreatedOBCs().
-			AnyTimes()
 
 		// when
 		err := k8sClient.Create(ctx, &edgeDevice)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -9,7 +9,7 @@ import (
 const (
 	EdgeDeviceSuccessfulRegistrationQuery = "k4e_operator_edge_devices_successful_registration"
 	EdgeDeviceFailedRegistrationQuery     = "k4e_operator_edge_devices_failed_registration"
-	CreatedOBCQuery                       = "k4e_operator_created_obc"
+	EdgeDeviceUnregistrationQuery         = "k4e_operator_edge_devices_unregistration"
 )
 
 var (
@@ -25,10 +25,10 @@ var (
 			Help: "Number of failed registration EdgeDevices",
 		},
 	)
-	createdOBC = prometheus.NewCounter(
+	unregisteredEdgeDevices = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: CreatedOBCQuery,
-			Help: "Number of created OBCs",
+			Name: EdgeDeviceUnregistrationQuery,
+			Help: "Number of unregistered EdgeDevices",
 		},
 	)
 )
@@ -38,7 +38,7 @@ func init() {
 	metrics.Registry.MustRegister(
 		registeredEdgeDevices,
 		failedToCompleteRegistrationEdgeDevices,
-		createdOBC,
+		unregisteredEdgeDevices,
 	)
 }
 
@@ -48,7 +48,7 @@ func init() {
 type Metrics interface {
 	IncEdgeDeviceSuccessfulRegistration()
 	IncEdgeDeviceFailedRegistration()
-	IncCreatedOBCs()
+	IncEdgeDeviceUnregistration()
 }
 
 func New() Metrics {
@@ -63,6 +63,6 @@ func (m *metricsImpl) IncEdgeDeviceSuccessfulRegistration() {
 func (m *metricsImpl) IncEdgeDeviceFailedRegistration() {
 	failedToCompleteRegistrationEdgeDevices.Inc()
 }
-func (m *metricsImpl) IncCreatedOBCs() {
-	createdOBC.Inc()
+func (m *metricsImpl) IncEdgeDeviceUnregistration() {
+	unregisteredEdgeDevices.Inc()
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -14,7 +14,7 @@ import (
 const (
 	numberOfEdgeDevicesSuccessfulRegisteredValue = 3
 	numberOfEdgeDevicesFailedToRegisterValue     = 1
-	numberOfCreatedOBCsValue                     = 2
+	numberOfEdgeDevicesUnregisteredValue         = 2
 )
 
 func TestMetrics(t *testing.T) {
@@ -54,12 +54,12 @@ var _ = Describe("Metrics", func() {
 
 	Context("EdgeDevice", func() {
 		It("correctly passes calls to the IncEdgeDeviceFailedRegistration", func() {
-			for i := 0; i < numberOfCreatedOBCsValue; i++ {
-				m.IncCreatedOBCs()
+			for i := 0; i < numberOfEdgeDevicesUnregisteredValue; i++ {
+				m.IncEdgeDeviceUnregistration()
 			}
 
 			//then
-			validateMetric(metrics.CreatedOBCQuery, numberOfCreatedOBCsValue)
+			validateMetric(metrics.EdgeDeviceUnregistrationQuery, numberOfEdgeDevicesUnregisteredValue)
 		})
 
 		It("correctly passes calls to the IncEdgeDeviceSuccessfulRegistration", func() {

--- a/internal/metrics/mock_metrics_api.go
+++ b/internal/metrics/mock_metrics_api.go
@@ -33,18 +33,6 @@ func (m *MockMetrics) EXPECT() *MockMetricsMockRecorder {
 	return m.recorder
 }
 
-// IncCreatedOBCs mocks base method.
-func (m *MockMetrics) IncCreatedOBCs() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "IncCreatedOBCs")
-}
-
-// IncCreatedOBCs indicates an expected call of IncCreatedOBCs.
-func (mr *MockMetricsMockRecorder) IncCreatedOBCs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncCreatedOBCs", reflect.TypeOf((*MockMetrics)(nil).IncCreatedOBCs))
-}
-
 // IncEdgeDeviceFailedRegistration mocks base method.
 func (m *MockMetrics) IncEdgeDeviceFailedRegistration() {
 	m.ctrl.T.Helper()
@@ -67,4 +55,16 @@ func (m *MockMetrics) IncEdgeDeviceSuccessfulRegistration() {
 func (mr *MockMetricsMockRecorder) IncEdgeDeviceSuccessfulRegistration() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncEdgeDeviceSuccessfulRegistration", reflect.TypeOf((*MockMetrics)(nil).IncEdgeDeviceSuccessfulRegistration))
+}
+
+// IncEdgeDeviceUnregistration mocks base method.
+func (m *MockMetrics) IncEdgeDeviceUnregistration() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IncEdgeDeviceUnregistration")
+}
+
+// IncEdgeDeviceUnregistration indicates an expected call of IncEdgeDeviceUnregistration.
+func (mr *MockMetricsMockRecorder) IncEdgeDeviceUnregistration() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncEdgeDeviceUnregistration", reflect.TypeOf((*MockMetrics)(nil).IncEdgeDeviceUnregistration))
 }

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -111,9 +111,12 @@ func (h *Handler) GetControlMessageForDevice(ctx context.Context, params yggdras
 	}
 
 	if edgeDevice.DeletionTimestamp != nil && !utils.HasFinalizer(&edgeDevice.ObjectMeta, YggdrasilWorkloadFinalizer) {
-		err = h.deviceRepository.RemoveFinalizer(ctx, edgeDevice, YggdrasilConnectionFinalizer)
-		if err != nil {
-			return operations.NewGetControlMessageForDeviceInternalServerError()
+		if utils.HasFinalizer(&edgeDevice.ObjectMeta, YggdrasilConnectionFinalizer) {
+			err = h.deviceRepository.RemoveFinalizer(ctx, edgeDevice, YggdrasilConnectionFinalizer)
+			if err != nil {
+				return operations.NewGetControlMessageForDeviceInternalServerError()
+			}
+			h.metrics.IncEdgeDeviceUnregistration()
 		}
 		message := h.createDisconnectCommand()
 		return operations.NewGetControlMessageForDeviceOK().WithPayload(message)

--- a/internal/yggdrasil/yggdrasil_test.go
+++ b/internal/yggdrasil/yggdrasil_test.go
@@ -146,11 +146,6 @@ var _ = Describe("Yggdrasil", func() {
 				Return(device, nil).
 				Times(1)
 
-			edgeDeviceRepoMock.EXPECT().
-				RemoveFinalizer(gomock.Any(), device, YggdrasilConnectionFinalizer).
-				Return(nil).
-				Times(1)
-
 			// when
 			res := handler.GetControlMessageForDevice(context.TODO(), params)
 			data := res.(*api.GetControlMessageForDeviceOK)
@@ -189,6 +184,10 @@ var _ = Describe("Yggdrasil", func() {
 			edgeDeviceRepoMock.EXPECT().
 				RemoveFinalizer(gomock.Any(), device, YggdrasilConnectionFinalizer).
 				Return(nil).
+				Times(1)
+
+			metricsMock.EXPECT().
+				IncEdgeDeviceUnregistration().
 				Times(1)
 
 			// when
@@ -362,7 +361,7 @@ var _ = Describe("Yggdrasil", func() {
 			Expect(config.Workloads).To(HaveLen(0))
 		})
 
-		It("Retrival of deployment failed", func() {
+		It("Retrieval of deployment failed", func() {
 			// given
 			device := getDevice("foo")
 			device.Status.Deployments = []v1alpha1.Deployment{{Name: "workload1"}}

--- a/main.go
+++ b/main.go
@@ -192,7 +192,6 @@ func main() {
 		EdgeDeviceRepository:    edgeDeviceRepository,
 		Claimer:                 claimer,
 		ObcAutoCreate:           Config.EnableObcAutoCreation,
-		Metrics:                 metricsObj,
 		MaxConcurrentReconciles: int(Config.MaxConcurrentReconciles),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EdgeDevice")


### PR DESCRIPTION
- Removed the counter for created OBC. This information can be obtained
  from the etcd by counting resources of OBC type.
- Added metrics to indicate on unregistration of a device.

Signed-off-by: Moti Asayag <masayag@redhat.com>