### PR TITLE
Allowing user to disable system metrics collection

### DIFF
--- a/api/v1alpha1/edgedevice_types.go
+++ b/api/v1alpha1/edgedevice_types.go
@@ -53,6 +53,9 @@ type SystemMetricsConfiguration struct {
 	// AllowList defines name and namespace of a ConfigMap containing
 	// list of system metrics that should be scraped
 	AllowList *ObjectRef `json:"allowList,omitempty"`
+
+	// Disabled when set to true instructs the device to turn off system metrics collection
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 type Retention struct {

--- a/config/crd/bases/management.k4e.io_edgedevices.yaml
+++ b/config/crd/bases/management.k4e.io_edgedevices.yaml
@@ -83,6 +83,10 @@ spec:
                         required:
                         - name
                         type: object
+                      disabled:
+                        description: Disabled when set to true instructs the device
+                          to turn off system metrics collection
+                        type: boolean
                       interval:
                         default: 60
                         description: Interval(in seconds) to scrape system metrics.

--- a/docs/design/http_api_swagger.md
+++ b/docs/design/http_api_swagger.md
@@ -777,6 +777,7 @@ Status: Internal Server Error
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | allow_list | [MetricsAllowList](#metrics-allow-list)| `MetricsAllowList` |  | | Specification of system metrics to be collected |  |
+| disabled | boolean| `bool` |  | | When true, turns system metrics collection off. False by default. |  |
 | interval | int32 (formatted integer)| `int32` |  | | Interval(in seconds) to scrape metrics endpoint. |  |
 
 

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -243,6 +243,7 @@ func (h *Handler) getDeviceMetricsConfiguration(ctx context.Context, edgeDevice 
 	if systemMetrics != nil {
 		metricsConfig.System = &models.SystemMetricsConfiguration{
 			Interval: systemMetrics.Interval,
+			Disabled: systemMetrics.Disabled,
 		}
 
 		allowListSpec := systemMetrics.AllowList

--- a/internal/yggdrasil/yggdrasil_test.go
+++ b/internal/yggdrasil/yggdrasil_test.go
@@ -1392,45 +1392,19 @@ var _ = Describe("Yggdrasil", func() {
 			Expect(config.Configuration.Metrics.Retention.MaxHours).To(Equal(maxHours))
 		})
 
-		It("should map system metrics interval", func() {
+		It("should map system metrics", func() {
 			// given
+			const (
+				allowListName      = "a-name"
+				allowListNamespace = "a-namespace"
+			)
 			interval := int32(3600)
 
 			device := getDevice("foo")
 			device.Spec.Metrics = &v1alpha1.MetricsConfiguration{
 				SystemMetrics: &v1alpha1.SystemMetricsConfiguration{
 					Interval: interval,
-				},
-			}
-
-			edgeDeviceRepoMock.EXPECT().
-				Read(gomock.Any(), "foo", testNamespace).
-				Return(device, nil).
-				Times(1)
-
-			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
-
-			// then
-			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
-			config := validateAndGetDeviceConfig(res)
-
-			Expect(config.Configuration.Metrics).ToNot(BeNil())
-			Expect(config.Configuration.Metrics.System).ToNot(BeNil())
-			Expect(config.Configuration.Metrics.System.Interval).To(Equal(interval))
-		})
-
-		It("should add allow-list configuration", func() {
-			// given
-			const (
-				allowListName      = "a-name"
-				allowListNamespace = "a-namespace"
-			)
-			allowList := models.MetricsAllowList{Names: []string{"fizz", "buzz"}}
-
-			device := getDevice("foo")
-			device.Spec.Metrics = &v1alpha1.MetricsConfiguration{
-				SystemMetrics: &v1alpha1.SystemMetricsConfiguration{
+					Disabled: true,
 					AllowList: &v1alpha1.ObjectRef{
 						Name:      allowListName,
 						Namespace: allowListNamespace,
@@ -1438,13 +1412,14 @@ var _ = Describe("Yggdrasil", func() {
 				},
 			}
 
-			allowListsMock.EXPECT().GenerateFromConfigMap(gomock.Any(), allowListName, allowListNamespace).
-				Return(&allowList, nil)
-
 			edgeDeviceRepoMock.EXPECT().
 				Read(gomock.Any(), "foo", testNamespace).
 				Return(device, nil).
 				Times(1)
+
+			allowList := models.MetricsAllowList{Names: []string{"fizz", "buzz"}}
+			allowListsMock.EXPECT().GenerateFromConfigMap(gomock.Any(), allowListName, allowListNamespace).
+				Return(&allowList, nil)
 
 			// when
 			res := handler.GetDataMessageForDevice(context.TODO(), params)
@@ -1455,6 +1430,11 @@ var _ = Describe("Yggdrasil", func() {
 
 			Expect(config.Configuration.Metrics).ToNot(BeNil())
 			Expect(config.Configuration.Metrics.System).ToNot(BeNil())
+
+			Expect(config.Configuration.Metrics.System.Interval).To(Equal(interval))
+
+			Expect(config.Configuration.Metrics.System.Disabled).To(BeTrue())
+
 			Expect(config.Configuration.Metrics.System.AllowList).ToNot(BeNil())
 			Expect(*config.Configuration.Metrics.System.AllowList).To(Equal(allowList))
 		})

--- a/models/system_metrics_configuration.go
+++ b/models/system_metrics_configuration.go
@@ -19,6 +19,9 @@ type SystemMetricsConfiguration struct {
 	// Specification of system metrics to be collected
 	AllowList *MetricsAllowList `json:"allow_list,omitempty"`
 
+	// When true, turns system metrics collection off. False by default.
+	Disabled bool `json:"disabled,omitempty"`
+
 	// Interval(in seconds) to scrape metrics endpoint.
 	Interval int32 `json:"interval,omitempty"`
 }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -778,6 +778,10 @@ func init() {
           "description": "Specification of system metrics to be collected",
           "$ref": "#/definitions/metrics-allow-list"
         },
+        "disabled": {
+          "description": "When true, turns system metrics collection off. False by default.",
+          "type": "boolean"
+        },
         "interval": {
           "description": "Interval(in seconds) to scrape metrics endpoint.",
           "type": "integer",
@@ -1630,6 +1634,10 @@ func init() {
         "allow_list": {
           "description": "Specification of system metrics to be collected",
           "$ref": "#/definitions/metrics-allow-list"
+        },
+        "disabled": {
+          "description": "When true, turns system metrics collection off. False by default.",
+          "type": "boolean"
         },
         "interval": {
           "description": "Interval(in seconds) to scrape metrics endpoint.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -245,6 +245,9 @@ definitions:
       allow_list:
         description: Specification of system metrics to be collected
         $ref: '#/definitions/metrics-allow-list'
+      disabled:
+        type: boolean
+        description: When true, turns system metrics collection off. False by default.
 
   metrics-allow-list:
     type: object


### PR DESCRIPTION
This PR allows user to disable system metrics collection from a device.