### PR TITLE
Custom labels for hardware

### DIFF
--- a/internal/hardware/hardware.go
+++ b/internal/hardware/hardware.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jakub-dzon/k4e-operator/api/v1alpha1"
+	"github.com/jakub-dzon/k4e-operator/internal/utils"
 	"github.com/jakub-dzon/k4e-operator/models"
 )
 
@@ -88,4 +89,46 @@ func MapHardware(hardware *models.HardwareInfo) *v1alpha1.Hardware {
 		}
 	}
 	return &hw
+}
+
+func MapLabels(hardware *models.HardwareInfo) map[string]string {
+	if hardware == nil {
+		return nil
+	}
+	var labels = make(map[string]string)
+
+	hostname, err := utils.NormalizeLabel(hardware.Hostname)
+	if err == nil {
+		labels["device.hostname"] = hostname
+	}
+
+	cpu := hardware.CPU
+	if cpu != nil {
+		arch, err := utils.NormalizeLabel(cpu.Architecture)
+		if err == nil {
+			labels["device.cpu-architecture"] = arch
+		}
+		model, err := utils.NormalizeLabel(cpu.ModelName)
+		if err == nil {
+			labels["device.cpu-model"] = model
+		}
+	}
+
+	systemVendor := hardware.SystemVendor
+	if systemVendor != nil {
+		manufacturer, err := utils.NormalizeLabel(systemVendor.Manufacturer)
+		if err == nil {
+			labels["device.system-manufacturer"] = manufacturer
+		}
+		productName, err := utils.NormalizeLabel(systemVendor.ProductName)
+		if err == nil {
+			labels["device.system-product"] = productName
+		}
+		serialNumber, err := utils.NormalizeLabel(systemVendor.SerialNumber)
+		if err == nil {
+			labels["device.system-serial"] = serialNumber
+		}
+	}
+
+	return labels
 }

--- a/internal/hardware/hardware_test.go
+++ b/internal/hardware/hardware_test.go
@@ -1,6 +1,8 @@
 package hardware_test
 
 import (
+	"strings"
+
 	"github.com/jakub-dzon/k4e-operator/api/v1alpha1"
 	"github.com/jakub-dzon/k4e-operator/internal/hardware"
 	"github.com/jakub-dzon/k4e-operator/models"
@@ -211,6 +213,48 @@ var _ = Describe("Hardware", func() {
 			Expect(result.SystemVendor.ProductName).To(Equal(testProductName))
 			Expect(result.SystemVendor.SerialNumber).To(Equal(testSerialNumber))
 			Expect(result.SystemVendor.Virtual).To(Equal(testVirtual))
+		})
+	})
+
+	Context("MapLabels", func() {
+		It("should accept nil input", func() {
+			// given
+			var input *models.HardwareInfo
+
+			// when
+			result := hardware.MapLabels(input)
+
+			// then
+			Expect(result).To(BeNil())
+		})
+
+		It("should handle nil fields in input", func() {
+			// given
+			input := models.HardwareInfo{}
+
+			// when
+			result := hardware.MapHardware(&input)
+
+			// then
+			Expect(result).NotTo(BeNil())
+		})
+
+		It("should map all labels", func() {
+			// given
+			input := testInputFull
+
+			//when
+			result := hardware.MapLabels(input)
+
+			// then
+			Expect(result).NotTo(BeNil())
+			Expect(len(result)).To(Equal(6))
+			Expect(result["device.hostname"]).To(Equal(testHostname))
+			Expect(result["device.cpu-architecture"]).To(Equal(strings.ToLower(testArchitecture)))
+			Expect(result["device.cpu-model"]).To(Equal(strings.ToLower(testModelName)))
+			Expect(result["device.system-manufacturer"]).To(Equal(strings.ToLower(testManufacturer)))
+			Expect(result["device.system-product"]).To(Equal(strings.ToLower(testProductName)))
+			Expect(result["device.system-serial"]).To(Equal(testSerialNumber))
 		})
 	})
 })

--- a/internal/heartbeat/synchronous-handler.go
+++ b/internal/heartbeat/synchronous-handler.go
@@ -2,11 +2,12 @@ package heartbeat
 
 import (
 	"context"
+	"time"
+
 	"github.com/jakub-dzon/k4e-operator/internal/repository/edgedevice"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"time"
 )
 
 type SynchronousHandler struct {
@@ -65,6 +66,10 @@ func (h *SynchronousHandler) process(ctx context.Context, notification Notificat
 	}
 
 	err = h.updater.updateStatus(ctx, edgeDevice, heartbeat)
+	if err != nil {
+		return err, true
+	}
+	err = h.updater.updateLabels(ctx, edgeDevice, heartbeat)
 	if err != nil {
 		return err, true
 	}

--- a/internal/heartbeat/updater.go
+++ b/internal/heartbeat/updater.go
@@ -2,6 +2,8 @@ package heartbeat
 
 import (
 	"context"
+	"time"
+
 	"github.com/jakub-dzon/k4e-operator/api/v1alpha1"
 	"github.com/jakub-dzon/k4e-operator/internal/hardware"
 	"github.com/jakub-dzon/k4e-operator/internal/repository/edgedevice"
@@ -10,7 +12,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 type Updater struct {
@@ -32,6 +33,10 @@ func (u *Updater) updateStatus(ctx context.Context, edgeDevice *v1alpha1.EdgeDev
 
 	err := u.deviceRepository.PatchStatus(ctx, edgeDevice, &patch)
 	return err
+}
+
+func (u *Updater) updateLabels(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice, heartbeat *models.Heartbeat) error {
+	return u.deviceRepository.UpdateLabels(ctx, edgeDevice, hardware.MapLabels(heartbeat.Hardware))
 }
 
 func (u *Updater) processEvents(edgeDevice *v1alpha1.EdgeDevice, events []*models.EventInfo) {

--- a/internal/repository/edgedevice/mock_edgedevice.go
+++ b/internal/repository/edgedevice/mock_edgedevice.go
@@ -122,3 +122,17 @@ func (mr *MockRepositoryMockRecorder) RemoveFinalizer(arg0, arg1, arg2 interface
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFinalizer", reflect.TypeOf((*MockRepository)(nil).RemoveFinalizer), arg0, arg1, arg2)
 }
+
+// UpdateLabels mocks base method.
+func (m *MockRepository) UpdateLabels(arg0 context.Context, arg1 *v1alpha1.EdgeDevice, arg2 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateLabels", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateLabels indicates an expected call of UpdateLabels.
+func (mr *MockRepositoryMockRecorder) UpdateLabels(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLabels", reflect.TypeOf((*MockRepository)(nil).UpdateLabels), arg0, arg1, arg2)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,6 +1,11 @@
 package utils
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -12,4 +17,24 @@ func HasFinalizer(cr *metav1.ObjectMeta, name string) bool {
 		}
 	}
 	return false
+}
+
+// NormalizeLabel normalizes label string according to k8s format
+func NormalizeLabel(name string) (string, error) {
+	// convert name to lowercase
+	name = strings.ToLower(name)
+
+	// slice string based on first and last alphanumeric character
+	firstLegal := strings.IndexFunc(name, func(c rune) bool { return unicode.IsLower(c) || unicode.IsDigit(c) })
+	lastLegal := strings.LastIndexFunc(name, func(c rune) bool { return unicode.IsLower(c) || unicode.IsDigit(c) })
+
+	if firstLegal < 0 {
+		return "", fmt.Errorf("The name doesn't contain a legal alphanumeric character")
+	}
+
+	name = name[firstLegal : lastLegal+1]
+	reg := regexp.MustCompile("[^a-z0-9-_.]+")
+	name = reg.ReplaceAllString(name, "")
+
+	return name, nil
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -4,6 +4,7 @@ import (
 	managementv1alpha1 "github.com/jakub-dzon/k4e-operator/api/v1alpha1"
 	"github.com/jakub-dzon/k4e-operator/internal/utils"
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -58,5 +59,27 @@ var _ = Describe("Utils", func() {
 			// then
 			Expect(found).To(BeFalse())
 		})
+	})
+
+	Context("NormalizeLabel", func() {
+		table.DescribeTable("should fail for an invalid format", func(tested string) {
+			result, err := utils.NormalizeLabel(tested)
+			Expect(result).To(Equal(""))
+			Expect(err).To(HaveOccurred())
+		},
+			table.Entry("Empty string", ""),
+			table.Entry("Non-alphanumeric characters", "$!@#$!@#$%"),
+			table.Entry("Only dashes without alphanumeric characters", "-----"),
+		)
+
+		table.DescribeTable("should normalize given label to expected format", func(tested string, expected string) {
+			result, err := utils.NormalizeLabel(tested)
+			Expect(result).To(Equal(expected))
+			Expect(err).NotTo(HaveOccurred())
+		},
+			table.Entry("CPU model", "Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz", "intelrcoretmi7-8665ucpu1.90ghz"),
+			table.Entry("CPU arch", "x86_64", "x86_64"),
+			table.Entry("Serial", "PF20YKWG;", "pf20ykwg"),
+		)
 	})
 })

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/jakub-dzon/k4e-operator/internal/devicemetrics"
 	"github.com/jakub-dzon/k4e-operator/internal/heartbeat"
 
@@ -335,6 +336,12 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 
 		if err != nil {
 			logger.Error(err, "cannot update EdgeDevice status")
+			h.metrics.IncEdgeDeviceFailedRegistration()
+			return operations.NewPostDataMessageForDeviceInternalServerError()
+		}
+		err = h.deviceRepository.UpdateLabels(ctx, &device, hardware.MapLabels(registrationInfo.Hardware))
+		if err != nil {
+			logger.Error(err, "cannot update EdgeDevice labels")
 			h.metrics.IncEdgeDeviceFailedRegistration()
 			return operations.NewPostDataMessageForDeviceInternalServerError()
 		}

--- a/internal/yggdrasil/yggdrasil_test.go
+++ b/internal/yggdrasil/yggdrasil_test.go
@@ -3,9 +3,10 @@ package yggdrasil_test
 import (
 	"context"
 	"fmt"
-	"github.com/jakub-dzon/k4e-operator/internal/devicemetrics"
 	"strings"
 	"time"
+
+	"github.com/jakub-dzon/k4e-operator/internal/devicemetrics"
 
 	"github.com/jakub-dzon/k4e-operator/internal/images"
 	"github.com/jakub-dzon/k4e-operator/internal/k8sclient"
@@ -1556,6 +1557,11 @@ var _ = Describe("Yggdrasil", func() {
 					Return(nil).
 					Times(1)
 
+				edgeDeviceRepoMock.EXPECT().
+					UpdateLabels(gomock.Any(), device, gomock.Any()).
+					Return(nil).
+					Times(1)
+
 				params := api.PostDataMessageForDeviceParams{
 					DeviceID: deviceName,
 					Message: &models.Message{
@@ -1590,6 +1596,11 @@ var _ = Describe("Yggdrasil", func() {
 				edgeDeviceRepoMock.EXPECT().
 					Read(gomock.Any(), deviceName, testNamespace).
 					Return(device, nil).
+					Times(1)
+
+				edgeDeviceRepoMock.EXPECT().
+					UpdateLabels(gomock.Any(), device, gomock.Any()).
+					Return(nil).
 					Times(1)
 
 				edgeDeviceRepoMock.EXPECT().
@@ -1643,6 +1654,11 @@ var _ = Describe("Yggdrasil", func() {
 				edgeDeviceRepoMock.EXPECT().
 					Read(gomock.Any(), deviceName, testNamespace).
 					Return(device, nil).
+					Times(1)
+
+				edgeDeviceRepoMock.EXPECT().
+					UpdateLabels(gomock.Any(), device, gomock.Any()).
+					Return(nil).
 					Times(1)
 
 				edgeDeviceRepoMock.EXPECT().
@@ -1748,6 +1764,11 @@ var _ = Describe("Yggdrasil", func() {
 					Return(nil).
 					Times(1)
 
+				edgeDeviceRepoMock.EXPECT().
+					UpdateLabels(gomock.Any(), device, gomock.Any()).
+					Return(nil).
+					Times(1)
+
 				params := api.PostDataMessageForDeviceParams{
 					DeviceID: deviceName,
 					Message: &models.Message{
@@ -1835,6 +1856,11 @@ var _ = Describe("Yggdrasil", func() {
 					Return(nil).
 					Times(1)
 
+				edgeDeviceRepoMock.EXPECT().
+					UpdateLabels(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil).
+					Times(1)
+
 				metricsMock.EXPECT().
 					IncEdgeDeviceSuccessfulRegistration().
 					AnyTimes()
@@ -1884,6 +1910,11 @@ var _ = Describe("Yggdrasil", func() {
 						Expect(edgeDevice.Status.Deployments).To(HaveLen(0))
 						Expect(edgeDevice.Status.Hardware.Hostname).To(Equal("fooHostname"))
 					}).
+					Return(nil).
+					Times(1)
+
+				edgeDeviceRepoMock.EXPECT().
+					UpdateLabels(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil).
 					Times(1)
 


### PR DESCRIPTION
We would like to use labels with hardware information to select devices where to run workload.

Here is how the labels look like after this change:

```yaml
    labels:
      device.cpu-architecture: x86_64
      device.cpu-model: intelrcoretmi7-8665ucpu1.90ghz
      device.hostname: localhost.localdomain
      device.system-manufacturer: lenovo
      device.system-product: 20n5s2nc1v
      device.system-serial: PF20YKWG
```

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>