### PR TITLE
Extract heartbeat handling

### DIFF
--- a/internal/heartbeat/api.go
+++ b/internal/heartbeat/api.go
@@ -1,0 +1,18 @@
+package heartbeat
+
+import (
+	"context"
+	"github.com/jakub-dzon/k4e-operator/models"
+)
+
+type Notification struct {
+	DeviceID  string
+	Namespace string
+	Heartbeat *models.Heartbeat
+	Retry     int32
+}
+
+type Handler interface {
+	Start()
+	Process(ctx context.Context, notification Notification) error
+}

--- a/internal/heartbeat/synchronous-handler.go
+++ b/internal/heartbeat/synchronous-handler.go
@@ -1,0 +1,73 @@
+package heartbeat
+
+import (
+	"context"
+	"github.com/jakub-dzon/k4e-operator/internal/repository/edgedevice"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"time"
+)
+
+type SynchronousHandler struct {
+	deviceRepository edgedevice.Repository
+	updater          Updater
+}
+
+func NewSynchronousHandler(deviceRepository edgedevice.Repository, recorder record.EventRecorder) *SynchronousHandler {
+	return &SynchronousHandler{
+		deviceRepository: deviceRepository,
+		updater: Updater{
+			deviceRepository: deviceRepository,
+			recorder:         recorder,
+		},
+	}
+}
+
+func (h *SynchronousHandler) Start() {
+	// noop
+}
+
+func (h *SynchronousHandler) Process(ctx context.Context, notification Notification) error {
+	// retry patching the edge device status
+	var err error
+	var retry bool
+	for i := 1; i < 5; i++ {
+		err, retry = h.process(ctx, notification)
+		if err == nil {
+			return nil
+		}
+		if !retry {
+			break
+		}
+
+		notification.Retry++
+		time.Sleep(time.Duration(i*50) * time.Millisecond)
+	}
+	return err
+}
+
+func (h *SynchronousHandler) process(ctx context.Context, notification Notification) (error, bool) {
+	logger := log.FromContext(ctx, "DeviceID", notification.DeviceID, "Namespace", notification.Namespace)
+	heartbeat := notification.Heartbeat
+	logger.V(1).Info("processing heartbeat", "content", heartbeat, "retry", notification.Retry)
+	edgeDevice, err := h.deviceRepository.Read(ctx, notification.DeviceID, notification.Namespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return err, false
+		}
+		return err, true
+	}
+
+	// Produce k8s events based on the device-worker events:
+	if notification.Retry == 0 {
+		h.updater.processEvents(edgeDevice, heartbeat.Events)
+	}
+
+	err = h.updater.updateStatus(ctx, edgeDevice, heartbeat)
+	if err != nil {
+		return err, true
+	}
+
+	return nil, false
+}

--- a/internal/heartbeat/updater.go
+++ b/internal/heartbeat/updater.go
@@ -1,0 +1,71 @@
+package heartbeat
+
+import (
+	"context"
+	"github.com/jakub-dzon/k4e-operator/api/v1alpha1"
+	"github.com/jakub-dzon/k4e-operator/internal/hardware"
+	"github.com/jakub-dzon/k4e-operator/internal/repository/edgedevice"
+	"github.com/jakub-dzon/k4e-operator/models"
+	v12 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+type Updater struct {
+	deviceRepository edgedevice.Repository
+	recorder         record.EventRecorder
+}
+
+func (u *Updater) updateStatus(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice, heartbeat *models.Heartbeat) error {
+	patch := client.MergeFrom(edgeDevice.DeepCopy())
+
+	edgeDevice.Status.LastSyncedResourceVersion = heartbeat.Version
+	edgeDevice.Status.LastSeenTime = v1.NewTime(time.Time(heartbeat.Time))
+	edgeDevice.Status.Phase = heartbeat.Status
+	if heartbeat.Hardware != nil {
+		edgeDevice.Status.Hardware = hardware.MapHardware(heartbeat.Hardware)
+	}
+	deployments := updateDeploymentStatuses(edgeDevice.Status.Deployments, heartbeat.Workloads)
+	edgeDevice.Status.Deployments = deployments
+
+	err := u.deviceRepository.PatchStatus(ctx, edgeDevice, &patch)
+	return err
+}
+
+func (u *Updater) processEvents(edgeDevice *v1alpha1.EdgeDevice, events []*models.EventInfo) {
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+
+		if event.Type == models.EventInfoTypeWarn {
+			u.recorder.Event(edgeDevice, v12.EventTypeWarning, event.Reason, event.Message)
+		} else {
+			u.recorder.Event(edgeDevice, v12.EventTypeNormal, event.Reason, event.Message)
+		}
+	}
+}
+
+func updateDeploymentStatuses(oldDeployments []v1alpha1.Deployment, workloads []*models.WorkloadStatus) []v1alpha1.Deployment {
+	deploymentMap := make(map[string]v1alpha1.Deployment)
+	for _, deploymentStatus := range oldDeployments {
+		deploymentMap[deploymentStatus.Name] = deploymentStatus
+	}
+	for _, status := range workloads {
+		if deployment, ok := deploymentMap[status.Name]; ok {
+			if string(deployment.Phase) != status.Status {
+				deployment.Phase = v1alpha1.EdgeDeploymentPhase(status.Status)
+				deployment.LastTransitionTime = v1.Now()
+			}
+			deployment.LastDataUpload = v1.NewTime(time.Time(status.LastDataUpload))
+			deploymentMap[status.Name] = deployment
+		}
+	}
+	var deployments []v1alpha1.Deployment
+	for _, deployment := range deploymentMap {
+		deployments = append(deployments, deployment)
+	}
+	return deployments
+}

--- a/internal/yggdrasil/yggdrasil_test.go
+++ b/internal/yggdrasil/yggdrasil_test.go
@@ -1528,7 +1528,7 @@ var _ = Describe("Yggdrasil", func() {
 				edgeDeviceRepoMock.EXPECT().
 					Read(gomock.Any(), deviceName, testNamespace).
 					Return(nil, fmt.Errorf("failed")).
-					Times(1)
+					Times(4)
 
 				params := api.PostDataMessageForDeviceParams{
 					DeviceID: deviceName,


### PR DESCRIPTION
This PR extracts `EdgeDevice` status update logic to an external package to prepare for other (async) status update strategies.